### PR TITLE
Add cleanup-on-success option to repackager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Earth Observation Datasets
 
 [![Build Status](https://travis-ci.org/GeoscienceAustralia/eo-datasets.svg?branch=develop)](https://travis-ci.org/GeoscienceAustralia/eo-datasets)
-[![Code Health](https://landscape.io/github/GeoscienceAustralia/eo-datasets/develop/landscape.svg?style=flat)](https://landscape.io/github/GeoscienceAustralia/eo-datasets/develop)
 [![Coverage Status](https://coveralls.io/repos/GeoscienceAustralia/eo-datasets/badge.svg?branch=develop)](https://coveralls.io/r/GeoscienceAustralia/eo-datasets?branch=develop)
 
 Packaging, metadata and provenance libraries for GA EO datasets. See [LICENSE](LICENSE) for

--- a/eodatasets/scripts/recompress.py
+++ b/eodatasets/scripts/recompress.py
@@ -373,8 +373,7 @@ def _recompress_image(
 class PathPath(click.Path):
     """A Click path argument that returns a pathlib Path, not a string"""
     def convert(self, value, param, ctx):
-        result = super().convert(value, param, ctx)
-        return Path(result) if result else None
+        return Path(super().convert(value, param, ctx))
 
 
 @click.command(help=__doc__)

--- a/eodatasets/scripts/recompress.py
+++ b/eodatasets/scripts/recompress.py
@@ -247,8 +247,8 @@ def _recompress_tar_member(
 
     # If it's a tif, check whether it's compressed.
     if member.name.lower().endswith('.tif'):
-        input_fp = open_member()
-        with rasterio.open(input_fp) as ds:
+        with open_member() as input_fp, \
+                rasterio.open(input_fp) as ds:
             if not ds.profile.get('compress'):
                 # No compression: let's compress it
                 with rasterio.MemoryFile(filename=member.name) as memory_file:
@@ -266,7 +266,7 @@ def _recompress_tar_member(
                     return
             else:
                 # It's already compressed, we'll fall through and copy it verbatim.
-                input_fp.close()
+                pass
 
     if member.size == 0:
         # Typically a directory entry.
@@ -274,7 +274,8 @@ def _recompress_tar_member(
         return
 
     # Copy unchanged into target (typically text/metadata files).
-    file_contents = open_member().read()
+    with open_member() as member:
+        file_contents = member.read()
     out_tar.addfile(new_member, io.BytesIO(file_contents))
     verify.add(io.BytesIO(file_contents), tmpdir / new_member.name)
     del file_contents

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
         'pyyaml',
         'rasterio',
         'shapely',
-        'scipy'
+        'scipy',
+        'structlog',
     ],
     tests_require=tests_require,
     extras_require={

--- a/tests/integration/test_recompress.py
+++ b/tests/integration/test_recompress.py
@@ -183,9 +183,13 @@ def test_recompress_gap_mask_dataset(tmp_path: Path):
     ####
     # If packaging is rerun, the output should not be touched!
     # ie. skip if output exists.
-    with expect_path_unchanged(expected_output,
-                               "Output file shouldn't be touched on rerun of compress"):
-        _run_recompress(input_path, output_base)
+    with (
+            expect_path_unchanged(expected_output,
+                                  "Output file shouldn't be touched on rerun of compress"),
+            expect_path_unchanged(input_path,
+                                  "Input path shouldn't be cleaned when output is skipped")
+    ):
+        _run_recompress(input_path, output_base, '--clean-inputs')
 
 
 def test_recompress_dirty_dataset(tmp_path: Path):


### PR DESCRIPTION
- Adds a `--clean-inputs` option which removes the original input dataset after successful recompress. (needed to avoid doubling the disk usage)
- Improves logging. Switched it to structlog.
- Add a `-f` option to read a list of inputs from a file (one per line)
- Various test improvements for edge cases


