### PR TITLE
Fix checksumdir calculation for s2_aws_pds; ls_usgs_l1 hardening

### DIFF
--- a/eodatasets/prepare/ls_usgs_l1_prepare.py
+++ b/eodatasets/prepare/ls_usgs_l1_prepare.py
@@ -274,7 +274,11 @@ def prepare_dataset_from_mtl(total_size: int,
         mtl_filename,
     )
 
-    product_id = mtl_doc['metadata_file_info']['landsat_product_id']
+
+    product_id = mtl_doc['metadata_file_info'].get('landsat_product_id')
+    if not product_id:
+        # Check both types of keys
+        product_id = mtl_doc['metadata_file_info']['landsat_scene_id']
 
     additional = additional_props or {}
 

--- a/eodatasets/prepare/s2_l1c_aws_pds_prepare.py
+++ b/eodatasets/prepare/s2_l1c_aws_pds_prepare.py
@@ -182,7 +182,7 @@ def prepare_dataset(path, datastrip_path=None):
         datastrip_path = path / 'datastrip'
     root_datastrip = ElementTree.parse(datastrip_path / 'metadata.xml').getroot()
     size_bytes = sum(os.path.getsize(p) for p in os.scandir(path))
-    checksum_sha1 = dirhash(path.parent, 'sha1')
+    checksum_sha1 = dirhash(path, 'sha1')
 
     # Get the datastrip metadata url and generated a deterministic src uuid
     datastrip_metadata, persisted_uuid = get_datastrip_info(path)


### PR DESCRIPTION
I believe the .parent statement on the checksumdir function was put in when the path to xml was provided to the prepare script; leaving it in can cause issues.

Landsat key fallback provided for level1  too.