### PR TITLE
Enabling old style of landsat ids

### DIFF
--- a/eodatasets/prepare/ls_usgs_l1_prepare.py
+++ b/eodatasets/prepare/ls_usgs_l1_prepare.py
@@ -274,7 +274,9 @@ def prepare_dataset_from_mtl(total_size: int,
         mtl_filename,
     )
 
-    product_id = mtl_doc['metadata_file_info']['landsat_product_id']
+    product_id = mtl_doc['metadata_file_info'].get(
+            'landsat_product_id',
+            mtl_doc['metadata_file_info']['landsat_scene_id'])
 
     additional = additional_props or {}
 


### PR DESCRIPTION
* Enable fallback to landsat_scene_id for older datasets.