### PR TITLE
Remove the remaining gdal cli calls from the image writer

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -226,7 +226,7 @@ class DatasetAssembler(EoFields):
         if not self._initialised_work_path:
             if not self._base_output_folder:
                 raise ValueError(
-                    "Dataset assembler was given no base path on construction: cannot write files."
+                    "Dataset assembler was given no base path on construction: cannot write new files."
                 )
 
             self._initialised_work_path = Path(

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -659,7 +659,7 @@ def _write_quicklook(
         *input_geobox.bounds,
     )
     reproj_grid = GridSpec(
-        (reprojected_width, reprojected_height), reprojected_transform, crs=out_crs
+        (reprojected_height, reprojected_width), reprojected_transform, crs=out_crs
     )
     # Calculate combined nodata mask
     nulls = numpy.zeros(input_geobox.shape, dtype="bool")

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         "ruamel.yaml",
         "scipy",
         "shapely",
-        "scikit-image",
         "structlog",
     ],
     tests_require=tests_require,


### PR DESCRIPTION
It's purely rio-based now, and removes the dependency on scikit-image.

There's further room for improvement, such as avoiding keeping whole bands in memory, but that was already the case in the previous code.