### PR TITLE
Address sample feedback: thumbnail configuration, simplify default fields, overview resampling

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -745,6 +745,7 @@ class DatasetAssembler(EoFields):
         resampling: Resampling = Resampling.average,
         static_stretch: Tuple[int, int] = None,
         percentile_stretch: Tuple[int, int] = (2, 98),
+        scale_factor=10,
         kind: str = None,
     ):
         """
@@ -784,15 +785,14 @@ class DatasetAssembler(EoFields):
             )
         grid = unique_grids[0]
 
-        scale_factor = 10
         FileWrite().create_thumbnail(
             tuple(path for grid, path in rgbs),
-            grid,
             thumb,
             out_scale=scale_factor,
             resampling=resampling,
             static_stretch=static_stretch,
             percentile_stretch=percentile_stretch,
+            input_geobox=grid,
         )
         self._checksum.add_file(thumb)
 

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -651,6 +651,7 @@ class DatasetAssembler(EoFields):
 
         dataset = DatasetDoc(
             id=self.dataset_id,
+            label=self.names.dataset_label,
             product=ProductDoc(
                 name=self.names.product_name, href=self.names.product_uri
             ),

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -743,6 +743,8 @@ class DatasetAssembler(EoFields):
         green: str,
         blue: str,
         resampling: Resampling = Resampling.average,
+        static_stretch: Tuple[int, int] = None,
+        percentile_stretch: Tuple[int, int] = (2, 98),
         kind: str = None,
     ):
         """
@@ -754,6 +756,10 @@ class DatasetAssembler(EoFields):
         them (it will be put in the filename).
 
         Eg. GA's ARD has thumbnails of kind 'nbar' and 'nbart'.
+
+        A linear stretch is performed on the colour. By default this is a dynamic 2% stretch
+        (the 2% and 98% percentile values of the input). The static_stretch parameter will
+        override this with a static range of values.
         """
         thumb = self.names.thumbnail_name(self._work_path, kind=kind)
         measurements = dict(
@@ -785,6 +791,8 @@ class DatasetAssembler(EoFields):
             thumb,
             out_scale=scale_factor,
             resampling=resampling,
+            static_stretch=static_stretch,
+            percentile_stretch=percentile_stretch,
         )
         self._checksum.add_file(thumb)
 

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -737,7 +737,14 @@ class DatasetAssembler(EoFields):
         self._is_finished = True
         return dataset.id, target_metadata_path
 
-    def write_thumbnail(self, red: str, green: str, blue: str, kind: str = None):
+    def write_thumbnail(
+        self,
+        red: str,
+        green: str,
+        blue: str,
+        resampling: Resampling = Resampling.average,
+        kind: str = None,
+    ):
         """
         Write a thumbnail for the dataset using the given measurements (specified by name) as r/g/b.
 
@@ -773,7 +780,11 @@ class DatasetAssembler(EoFields):
 
         scale_factor = 10
         FileWrite().create_thumbnail(
-            tuple(path for grid, path in rgbs), grid, thumb, out_scale=scale_factor
+            tuple(path for grid, path in rgbs),
+            grid,
+            thumb,
+            out_scale=scale_factor,
+            resampling=resampling,
         )
         self._checksum.add_file(thumb)
 

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -211,6 +211,7 @@ class DatasetAssembler(EoFields):
         self._accessories: Dict[str, Path] = {}
 
         self._props = StacPropertyView()
+        self._label = None
 
         if naming_conventions == "default":
             self.names = ComplicatedNamingConventions(self)
@@ -243,6 +244,27 @@ class DatasetAssembler(EoFields):
         return self._props
 
     @property
+    def label(self) -> Optional[str]:
+        """
+        An optional displayable string to identify this dataset.
+
+        These are often used when when presenting a list of datasets, such as in search results or a filesystem folder.
+        They are unstructured, but should be more humane than showing a list of UUIDs.
+
+        By convention they have no spaces, due to their usage in filenames.
+
+        Eg. 'ga_ls5t_ard_3-0-0_092084_2009-12-17_final' or USGS's 'LT05_L1TP_092084_20091217_20161017_01_T1'
+
+        A label will be auto-generated using the naming-conventions, but you can manually override it by
+        setting this property.
+        """
+        return self._label or self.names.dataset_label
+
+    @label.setter
+    def label(self, val: str):
+        self._label = val
+
+    @property
     def destination_folder(self) -> Path:
         """
         The folder where the finished package will reside.
@@ -258,7 +280,11 @@ class DatasetAssembler(EoFields):
         """
         Prevent against users accidentally setting new properties on the assembler (it has happened multiple times).
         """
-        if hasattr(self, "_finished_init_") and not hasattr(self, name):
+        if (
+            name != "label"
+            and hasattr(self, "_finished_init_")
+            and not hasattr(self, name)
+        ):
             raise TypeError(
                 f"Cannot set new field '{name}' on an assembler. "
                 f"(Perhaps you meant to set it on the .properties?)"

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -389,7 +389,7 @@ class DatasetAssembler(EoFields):
         name: str,
         path: Path,
         overviews=images.DEFAULT_OVERVIEWS,
-        overview_resampling=Resampling.nearest,
+        overview_resampling=Resampling.average,
         expand_valid_data=True,
         file_id: str = None,
     ):
@@ -416,7 +416,7 @@ class DatasetAssembler(EoFields):
         name: str,
         ds: DatasetReader,
         overviews=images.DEFAULT_OVERVIEWS,
-        overview_resampling=Resampling.nearest,
+        overview_resampling=Resampling.average,
         expand_valid_data=True,
         file_id=None,
     ):
@@ -448,7 +448,7 @@ class DatasetAssembler(EoFields):
         grid_spec: GridSpec,
         nodata=None,
         overviews=images.DEFAULT_OVERVIEWS,
-        overview_resampling=Resampling.nearest,
+        overview_resampling=Resampling.average,
         expand_valid_data=True,
         file_id: str = None,
     ):
@@ -485,7 +485,7 @@ class DatasetAssembler(EoFields):
         dataset: Dataset,
         nodata: int,
         overviews=images.DEFAULT_OVERVIEWS,
-        overview_resampling=Resampling.nearest,
+        overview_resampling=Resampling.average,
         expand_valid_data=True,
         file_id=None,
     ):

--- a/eodatasets3/dataset.schema.yaml
+++ b/eodatasets3/dataset.schema.yaml
@@ -11,7 +11,9 @@ properties:
   id:
     type: string
     format: uuid
-
+  label:
+    type: string
+    pattern: "^[a-zA-Z0-9-_]*$"
   product:
     title: Product
     type: object

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -581,7 +581,7 @@ class FileWrite:
         out_scale=10,
         # TODO: infer source range?
         src_range=(1, 3500),
-        resampling=Resampling.bilinear,
+        resampling=Resampling.average,
         compress_quality: int = 85,
     ):
         """

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -236,6 +236,8 @@ class MeasurementRecord:
     def as_geo_docs(self) -> Tuple[CRS, Dict[str, GridDoc], Dict[str, MeasurementDoc]]:
         """Calculate combined geo information for metadata docs"""
 
+        if not self._measurements_per_grid:
+            return None, None, None
         # Order grids from most to fewest measurements.
         # PyCharm's typing seems to get confused by the sorted() call.
         # noinspection PyTypeChecker

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -687,27 +687,14 @@ def _write_quicklook(
             array = ds.read(1)
             valid_data_mask &= array != ds.nodata
             if not static_range:
-                calculated_range = (
-                    # "the maximum of the 2-percentiles"
-                    max(
-                        np.percentile(
-                            array[valid_data_mask],
-                            percentile_range[0],
-                            interpolation="lower",
-                        ),
-                        calculated_range[0],
-                    ),
-                    # "the minimum of the 98-percentiles"
-                    min(
-                        np.percentile(
-                            array[valid_data_mask],
-                            percentile_range[1],
-                            interpolation="higher",
-                        ),
-                        calculated_range[1],
-                    ),
+                low, high = np.percentile(
+                    array[valid_data_mask], percentile_range, interpolation="nearest"
                 )
-
+                calculated_range = (
+                    max(low, calculated_range[0]),
+                    min(high, calculated_range[1]),
+                )
+            del array
     if not static_range:
         static_range = calculated_range
     ql_write_args = dict(

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -149,7 +149,7 @@ class ComplicatedNamingConventions:
             return None
         return int(self.dataset.dataset_version.split(".")[0])
 
-    def _product_group(self, subname=None):
+    def _product_group(self, subname=None) -> str:
         # Fallback to the whole product's name
         if not subname:
             subname = self.dataset.product_family
@@ -243,30 +243,32 @@ class ComplicatedNamingConventions:
 
     def _file(self, work_dir: Path, file_id: str, suffix: str, sub_name: str = None):
         p = self.dataset
-        if p.dataset_version:
-            version = p.dataset_version.replace(".", "-")
-        else:
-            version = "beta"
 
-        maturity = p.properties.get("dea:dataset_maturity") or "user"
-        if file_id:
-            end = f'{maturity}_{file_id.replace("_", "-")}.{suffix}'
-        else:
-            end = f"{maturity}.{suffix}"
+        version = p.dataset_version.replace(".", "-") if p.dataset_version else None
+        maturity: str = p.properties.get("dea:dataset_maturity")
+        file_id = file_id.replace("_", "-") if file_id else None
 
-        return work_dir / "_".join(
-            (
-                self._product_group(sub_name),
-                version,
-                self._displayable_region_code,
-                f"{p.datetime:%Y-%m-%d}",
-                end,
+        return work_dir / (
+            "_".join(
+                [
+                    p
+                    for p in (
+                        self._product_group(sub_name),
+                        version,
+                        self._displayable_region_code,
+                        f"{p.datetime:%Y-%m-%d}",
+                        maturity,
+                        file_id,
+                    )
+                    if p
+                ]
             )
+            + f".{suffix}"
         )
 
     @property
     def _displayable_region_code(self):
-        return self.dataset.region_code or "x"
+        return self.dataset.region_code
 
     def thumbnail_name(self, work_dir: Path, kind: str = None, suffix: str = "jpg"):
         self._check_enough_properties_to_name()

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -290,7 +290,6 @@ def prepare_and_write(
         p.properties["eo:sun_azimuth"] = mtl_doc["image_attributes"]["sun_azimuth"]
         p.properties["eo:sun_elevation"] = mtl_doc["image_attributes"]["sun_elevation"]
         p.properties["landsat:collection_number"] = usgs_collection_number
-
         for section, fields in _COPYABLE_MTL_FIELDS:
             for field in fields:
                 value = mtl_doc[section].get(field)

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -171,7 +171,6 @@ class StacPropertyView(collections.abc.Mapping):
     KNOWN_STAC_PROPERTIES: Mapping[str, Optional[NormaliseValueFn]] = {
         "datetime": datetime_type,
         "dea:dataset_maturity": of_enum_type(("final", "interim", "nrt"), lower=True),
-        "dea:processing_level": None,
         "dtr:end_datetime": datetime_type,
         "dtr:start_datetime": datetime_type,
         "eo:azimuth": float,

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -178,7 +178,7 @@ class StacPropertyView(collections.abc.Mapping):
         "eo:epsg": None,
         "eo:gsd": None,
         "eo:instrument": None,
-        "eo:off_nadir": None,
+        "eo:off_nadir": float,
         "eo:platform": normalise_platform,
         "eo:constellation": None,
         "eo:sun_azimuth": degrees_type,
@@ -410,3 +410,17 @@ class EoFields(metaclass=ABCMeta):
     @region_code.setter
     def region_code(self, value: str):
         self.properties["odc:region_code"] = value
+
+    @property
+    def maturity(self) -> str:
+        """
+        The dataset maturity. The same data may be processed multiple times -- becoming more
+        mature -- as new ancillary data becomes available.
+
+        Typical values (from least to most mature): "nrt", "interim", "final"
+        """
+        return self.properties.get("dea:dataset_maturity")
+
+    @maturity.setter
+    def maturity(self, value):
+        self.properties["dea:dataset_maturity"] = value

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -258,7 +258,13 @@ def _to_doc(d: DatasetDoc, with_formatting: bool):
                 doc["measurements"].yaml_add_eol_comment(band_doc.alias, band_name)
 
         _add_space_before(
-            doc, "id", "crs", "properties", "measurements", "accessories", "lineage"
+            doc,
+            "label" if "label" in doc else "id",
+            "crs",
+            "properties",
+            "measurements",
+            "accessories",
+            "lineage",
         )
 
         p: CommentedMap = doc["properties"]

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -240,7 +240,7 @@ def _to_doc(d: DatasetDoc, with_formatting: bool):
         sorted(doc["properties"].items(), key=_stac_key_order)
     )
 
-    if d.geometry:
+    if d.geometry is not None:
         doc["geometry"] = shapely.geometry.mapping(d.geometry)
     doc["id"] = str(d.id)
 
@@ -253,9 +253,10 @@ def _to_doc(d: DatasetDoc, with_formatting: bool):
                 _use_compact_format(grid, "shape", "transform")
 
         # Add user-readable names for measurements as a comment if present.
-        for band_name, band_doc in d.measurements.items():
-            if band_doc.alias and band_name.lower() != band_doc.alias.lower():
-                doc["measurements"].yaml_add_eol_comment(band_doc.alias, band_name)
+        if d.measurements:
+            for band_name, band_doc in d.measurements.items():
+                if band_doc.alias and band_name.lower() != band_doc.alias.lower():
+                    doc["measurements"].yaml_add_eol_comment(band_doc.alias, band_name)
 
         _add_space_before(
             doc,
@@ -276,8 +277,9 @@ def _to_doc(d: DatasetDoc, with_formatting: bool):
 def _use_compact_format(d: dict, *keys):
     """Change the given sequence to compact YAML form"""
     for key in keys:
-        d[key] = CommentedSeq(d[key])
-        d[key].fa.set_flow_style()
+        if key in d:
+            d[key] = CommentedSeq(d[key])
+            d[key].fa.set_flow_style()
 
 
 def _add_space_before(d: CommentedMap, *keys):

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -98,7 +98,9 @@ def _unpack_products(
             if (p.platform, product) in _THUMBNAILS:
                 red, green, blue = _THUMBNAILS[(p.platform, product)]
                 with do(f"Thumbnailing {product}"):
-                    p.write_thumbnail(red, green, blue, kind=product)
+                    p.write_thumbnail(
+                        red, green, blue, kind=product, static_stretch=(1, 3000)
+                    )
 
 
 def write_measurement_h5(

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -514,8 +514,6 @@ def package(
             p.dataset_version = f"{org_collection_number}.0.0"
             p.region_code = _extract_reference_code(p, granule.name)
 
-            p.properties["dea:processing_level"] = "level-2"
-
             _read_wagl_metadata(p, granule_group)
             _read_gqa_doc(p, granule.gqa_doc)
             _read_fmask_doc(p, granule.fmask_doc)

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -531,7 +531,10 @@ def package(
                 if granule.fmask_image:
                     with do(f"Writing fmask from {granule.fmask_image} "):
                         p.write_measurement(
-                            "oa:fmask", granule.fmask_image, expand_valid_data=False
+                            "oa:fmask",
+                            granule.fmask_image,
+                            expand_valid_data=False,
+                            overview_resampling=Resampling.mode,
                         )
 
             with do("Finishing package"):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,10 +131,12 @@ def expected_l1_ls8_folder(
     collection="1",
     lineage=None,
 ):
-    product_name = f"{organisation.split('.')[0]}_ls8c_level1_{collection}"
+    org_code = organisation.split(".")[0]
+    product_name = f"{org_code}_ls8c_level1_{collection}"
     return {
         "$schema": "https://schemas.opendatacube.org/dataset",
         "id": "a780754e-a884-58a7-9ac0-df518a67f59d",
+        "label": f"{product_name}-0-20170405_090084_2016-01-21",
         "product": {
             "name": product_name,
             "href": f"https://collections.dea.ga.gov.au/product/{product_name}",
@@ -290,6 +292,7 @@ def l1_ls7_tarball_md_expected(
     return {
         "$schema": "https://schemas.opendatacube.org/dataset",
         "id": "f23c5fa2-3321-5be9-9872-2be73fee12a6",
+        "label": "usgs_ls7e_level1_1-0-20161124_104078_2013-04-29",
         "product": {
             "name": "usgs_ls7e_level1_1",
             "href": "https://collections.dea.ga.gov.au/product/usgs_ls7e_level1_1",
@@ -427,6 +430,7 @@ def l1_ls5_tarball_md_expected(
     return {
         "$schema": "https://schemas.opendatacube.org/dataset",
         "id": "b0d31709-dda4-5a67-9fdf-3ae026a99a72",
+        "label": "usgs_ls5t_level1_1-0-20161231_090085_1997-04-06",
         "product": {
             "name": "usgs_ls5t_level1_1",
             "href": "https://collections.dea.ga.gov.au/product/usgs_ls5t_level1_1",

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -84,6 +84,7 @@ def test_dea_style_package(
         {
             "$schema": "https://schemas.opendatacube.org/dataset",
             "id": dataset_id,
+            "label": "ga_ls8c_ones_3-0-0_090084_2016-01-21_final",
             "product": {
                 # This was added automatically because we chose 'dea' conventions.
                 "href": "https://collections.dea.ga.gov.au/product/ga_ls8c_ones_3",

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -32,7 +32,6 @@ def test_dea_style_package(
         p.platform = "LANDSAT_8"  # to: 'landsat-8'
         p.processed = "2016-03-04 14:23:30Z"  # into a date.
         p.properties["dea:dataset_maturity"] = "FINAL"  # lowercased
-        p.properties["dea:processing_level"] = "level-2"
 
         # Write a measurement from a numpy array, using the source dataset's grid spec.
         p.write_measurement_numpy(
@@ -127,7 +126,6 @@ def test_dea_style_package(
             "properties": {
                 "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435),
                 "dea:dataset_maturity": "final",
-                "dea:processing_level": "level-2",
                 "odc:dataset_version": "3.0.0",
                 "odc:file_format": "GeoTIFF",
                 "odc:processing_datetime": "2016-03-04T14:23:30",

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -31,7 +31,8 @@ def test_dea_style_package(
         # Known properties are normalised (see tests at bottom of file)
         p.platform = "LANDSAT_8"  # to: 'landsat-8'
         p.processed = "2016-03-04 14:23:30Z"  # into a date.
-        p.properties["dea:dataset_maturity"] = "FINAL"  # lowercased
+        p.maturity = "FINAL"  # lowercased
+        p.properties["eo:off_nadir"] = "34"  # into a number
 
         # Write a measurement from a numpy array, using the source dataset's grid spec.
         p.write_measurement_numpy(
@@ -136,6 +137,7 @@ def test_dea_style_package(
                 "eo:platform": "landsat-8",  # matching Stac's examples for capitalisation.
                 "eo:instrument": "OLI_TIRS",  # matching Stac's examples for capitalisation.
                 "eo:cloud_cover": 93.22,
+                "eo:off_nadir": 34.0,
                 "eo:gsd": 15.0,
                 "eo:sun_azimuth": 74.007_443_8,
                 "eo:sun_elevation": 55.486_483,
@@ -189,8 +191,6 @@ def test_minimal_package(tmp_path: Path, l1_ls8_folder: Path):
         dataset_id, metadata_path = p.done()
 
     assert dataset_id is not None
-    for f in out.rglob("*"):
-        print(str(f.name))
     assert_file_structure(
         out,
         {

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -199,10 +199,10 @@ def test_minimal_package(tmp_path: Path, l1_ls8_folder: Path):
                     "07": {
                         "04": {
                             # Set a dataset version to get rid of 'beta' label.
-                            "quaternarius_beta_x_2019-07-04_user.odc-metadata.yaml": "",
-                            "quaternarius_beta_x_2019-07-04_user.proc-info.yaml": "",
-                            "quaternarius_beta_x_2019-07-04_user_blue.tif": "",
-                            "quaternarius_beta_x_2019-07-04_user.sha1": "",
+                            "quaternarius_2019-07-04.odc-metadata.yaml": "",
+                            "quaternarius_2019-07-04.proc-info.yaml": "",
+                            "quaternarius_2019-07-04_blue.tif": "",
+                            "quaternarius_2019-07-04.sha1": "",
                         }
                     }
                 }

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import numpy
 import pytest
+from ruamel import yaml
 
 from eodatasets3.assemble import DatasetAssembler
 from eodatasets3.images import GridSpec
@@ -209,6 +210,23 @@ def test_minimal_package(tmp_path: Path, l1_ls8_folder: Path):
             }
         },
     )
+
+
+def test_dataset_no_measurements(tmp_path: Path):
+    """Can we make a dataset with no measurements? (eg. telemetry data)"""
+    with DatasetAssembler(tmp_path) as p:
+        # A custom label too.
+        p.label = "chipmonk_sightings_2019"
+        p.datetime = datetime(2019, 1, 1)
+        p.product_family = "chipmonk_sightings"
+        p.processed_now()
+
+        dataset_id, metadata_path = p.done()
+
+    with metadata_path.open("r") as f:
+        doc = yaml.load(f)
+
+    assert doc["label"] == "chipmonk_sightings_2019", "Couldn't override label field"
 
 
 def test_complain_about_missing_fields(tmp_path: Path, l1_ls8_folder: Path):

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -4,66 +4,43 @@ from eodatasets3 import images
 
 
 def test_rescale_intensity():
+    # Example was generated via:
+    #     scipy.ndimage.rotate(np.arange(1000, 8000, 100).reshape((7,10)), 45, cval=-99)
 
-    # Generated via: scipy.ndimage.rotate(np.arange(1000, 8000, 100).reshape((7,10)), 45, cval=-99)
+    # (Using a variable so the array is more spaced-out & readable)
+    nada = -999
     original_image = np.array(
         [
-            [-99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99],
-            [-99, -99, -99, -99, -99, -99, 1852, 2730, -99, -99, -99, -99],
-            [-99, -99, -99, -99, -99, 1711, 2570, 3428, 4169, -99, -99, -99],
-            [-99, -99, -99, -99, 1568, 2432, 3287, 4009, 4805, 5610, -99, -99],
-            [-99, -99, -99, 1427, 2291, 3144, 3871, 4663, 5451, 6181, 7049, -99],
-            [-99, -99, 1284, 2149, 3003, 3729, 4521, 5312, 6040, 6889, 7757, -99],
-            [-99, 1143, 2011, 2860, 3588, 4379, 5171, 5897, 6751, 7616, -99, -99],
-            [-99, 1851, 2719, 3449, 4237, 5029, 5756, 6609, 7473, -99, -99, -99],
-            [-99, -99, 3290, 4095, 4891, 5613, 6468, 7332, -99, -99, -99, -99],
-            [-99, -99, -99, 4731, 5472, 6330, 7189, -99, -99, -99, -99, -99],
-            [-99, -99, -99, -99, 6170, 7048, -99, -99, -99, -99, -99, -99],
-            [-99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99],
+            [nada, nada, nada, nada, nada, nada, nada, nada, nada, nada, nada, nada],
+            [nada, nada, nada, nada, nada, nada, 1852, 2730, nada, nada, nada, nada],
+            [nada, nada, nada, nada, nada, 1711, 2570, 3428, 4169, nada, nada, nada],
+            [nada, nada, nada, nada, 1568, 2432, 3287, 4009, 4805, 5610, nada, nada],
+            [nada, nada, nada, 1427, 2291, 3144, 3871, 4663, 5451, 6181, 7049, nada],
+            [nada, nada, 1284, 2149, 3003, 3729, 4521, 5312, 6040, 6889, 7757, nada],
+            [nada, 1143, 2011, 2860, 3588, 4379, 5171, 5897, 6751, 7616, nada, nada],
+            [nada, 1851, 2719, 3449, 4237, 5029, 5756, 6609, 7473, nada, nada, nada],
+            [nada, nada, 3290, 4095, 4891, 5613, 6468, 7332, nada, nada, nada, nada],
+            [nada, nada, nada, 4731, 5472, 6330, 7189, nada, nada, nada, nada, nada],
+            [nada, nada, nada, nada, 6170, 7048, nada, nada, nada, nada, nada, nada],
+            [nada, nada, nada, nada, nada, nada, nada, nada, nada, nada, nada, nada],
         ]
     )
     unmodified = original_image.copy()
 
-    # Note that the nodata values are not scaled (a previous bug!)
-    # they're translated to the output nodata value (0).
-
-    non = 0  # (Using a variable so the array is more spaced-out & readable)
-    expected_dynamic_rescale = np.array(
-        [
-            [non, non, non, non, non, non, non, non, non, non, non, non],
-            [non, non, non, non, non, non, 22, 58, non, non, non, non],
-            [non, non, non, non, non, 17, 51, 86, 116, non, non, non],
-            [non, non, non, non, 11, 46, 80, 109, 141, 174, non, non],
-            [non, non, non, 5, 40, 74, 104, 136, 167, 197, 232, non],
-            [non, non, non, 34, 69, 98, 130, 162, 191, 225, 255, non],
-            [non, non, 29, 63, 92, 124, 156, 185, 220, 255, non, non],
-            [non, 22, 57, 87, 118, 150, 180, 214, 249, non, non, non],
-            [non, non, 80, 113, 145, 174, 208, 243, non, non, non, non],
-            [non, non, non, 138, 168, 203, 237, non, non, non, non, non],
-            [non, non, non, non, 196, 232, non, non, non, non, non, non],
-            [non, non, non, non, non, non, non, non, non, non, non, non],
-        ],
-        dtype=np.uint8,
-    )
-
-    dynamically_rescaled = images.rescale_intensity(original_image, image_nodata=-99)
-    print("Dynamically rescaled result: ")
-    print(repr(dynamically_rescaled))
-    assert np.array_equal(dynamically_rescaled, expected_dynamic_rescale)
     assert np.array_equal(
         original_image, unmodified
     ), "rescale_intensity modified the input image"
 
     staticly_rescaled = images.rescale_intensity(
-        original_image,
-        static_range=(4000, 6000),
-        out_range=(100, 255),
-        image_nodata=-99,
+        original_image, in_range=(4000, 6000), out_range=(100, 255), image_nodata=-999
     )
     print("Statically rescaled result: ")
     print(repr(staticly_rescaled))
 
-    # Notice how many will be clipped to the min (100) without falling into nodata.
+    # - Note that the nodata values are not scaled (a previous bug!)
+    #   they're translated to the output nodata value (0).
+    # - Note how many will be clipped to the min (100) without falling into nodata.
+    non = 0
     expected_static_rescale = np.array(
         [
             [non, non, non, non, non, non, non, non, non, non, non, non],
@@ -82,3 +59,102 @@ def test_rescale_intensity():
         dtype=np.uint8,
     )
     assert np.array_equal(staticly_rescaled, expected_static_rescale)
+
+
+def test_calc_range():
+    # Test that the correct value range and valid data arrays are calculated.
+
+    # Test arrays generated via:
+    # >>> scipy.ndimage.rotate(np.arange(10, 70, 1).reshape((6, 10)), 55, cval=-11)
+    # >>> scipy.ndimage.rotate(np.arange(20, 80, 1).reshape((6, 10)), 50, cval=-11)
+    # >>> scipy.ndimage.rotate(np.arange(30, 90, 1).reshape((6, 10)), 55, cval=-11)
+
+    # They have:
+    # - slightly different values to test the highest/lowest value range calculation
+    #   (it should be across all bands)
+    # - And slightly different rotation to test the combined valid_data mask.
+
+    no = -11
+    r_array = np.array(
+        [
+            [no, no, no, no, no, no, no, no, no, no, no],
+            [no, no, no, no, no, no, 25, no, no, no, no],
+            [no, no, no, no, no, 21, 31, 40, no, no, no],
+            [no, no, no, no, 17, 27, 36, 45, 53, 64, no],
+            [no, no, no, 15, 23, 32, 41, 49, 59, 68, no],
+            [no, no, no, 18, 29, 37, 46, 54, 65, no, no],
+            [no, no, 14, 25, 33, 42, 50, 61, no, no, no],
+            [no, 11, 20, 30, 38, 47, 56, 64, no, no, no],
+            [no, 15, 26, 34, 43, 52, 62, no, no, no, no],
+            [no, no, no, 39, 48, 58, no, no, no, no, no],
+            [no, no, no, no, 54, no, no, no, no, no, no],
+            [no, no, no, no, no, no, no, no, no, no, no],
+        ]
+    )
+    g_array = np.array(
+        [
+            [no, no, no, no, no, no, no, no, no, no, no],
+            [no, no, no, no, no, no, 31, no, no, no, no],
+            [no, no, no, no, no, 28, 38, 47, no, no, no],
+            [no, no, no, no, 26, 35, 44, 52, 60, 68, no],
+            [no, no, no, 24, 32, 41, 49, 58, 66, 76, no],
+            [no, no, no, 29, 39, 47, 55, 63, 73, no, no],
+            [no, no, 26, 36, 44, 52, 60, 70, no, no, no],
+            [no, 23, 33, 41, 50, 58, 67, 75, no, no, no],
+            [no, 31, 39, 47, 55, 64, 73, no, no, no, no],
+            [no, no, no, 52, 61, 71, no, no, no, no, no],
+            [no, no, no, no, 68, no, no, no, no, no, no],
+            [no, no, no, no, no, no, no, no, no, no, no],
+        ]
+    )
+    b_array = np.array(
+        [
+            [no, no, no, no, no, no, no, no, no, no, no],
+            [no, no, no, no, no, no, 45, no, no, no, no],
+            [no, no, no, no, no, 41, 51, 60, no, no, no],
+            [no, no, no, no, 37, 47, 56, 65, 73, 84, no],
+            [no, no, no, 35, 43, 52, 61, 69, 79, 88, no],
+            [no, no, no, 38, 49, 57, 66, 74, 85, no, no],
+            [no, no, 34, 45, 53, 62, 70, 81, no, no, no],
+            [no, 31, 40, 50, 58, 67, 76, 84, no, no, no],
+            [no, 35, 46, 54, 63, 72, 82, no, no, no, no],
+            [no, no, no, 59, 68, 78, no, no, no, no, no],
+            [no, no, no, no, 74, no, no, no, no, no, no],
+            [no, no, no, no, no, no, no, no, no, no, no],
+        ]
+    )
+
+    mask = np.ones(r_array.shape, dtype=np.bool)
+    calculated_range = images.read_valid_mask_and_value_range(
+        mask,
+        ((r_array, no), (g_array, no), (b_array, no)),
+        calculate_percentiles=(2, 98),
+    )
+
+    expected_combined_mask = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+            [0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0],
+            [0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=bool,
+    )
+
+    assert np.array_equal(expected_combined_mask, mask), (
+        f"Combined mask isn't as expected. "
+        f"Diff: {repr(np.logical_xor(expected_combined_mask, mask))}"
+    )
+
+    assert calculated_range == (
+        34,
+        65,
+    ), f"Unexpected 2/98 percentile values: {calculated_range}"

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from eodatasets3 import images
+
+
+def test_rescale_intensity():
+
+    # Generated via: scipy.ndimage.rotate(np.arange(1000, 8000, 100).reshape((7,10)), 45, cval=-99)
+    original_image = np.array(
+        [
+            [-99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99],
+            [-99, -99, -99, -99, -99, -99, 1852, 2730, -99, -99, -99, -99],
+            [-99, -99, -99, -99, -99, 1711, 2570, 3428, 4169, -99, -99, -99],
+            [-99, -99, -99, -99, 1568, 2432, 3287, 4009, 4805, 5610, -99, -99],
+            [-99, -99, -99, 1427, 2291, 3144, 3871, 4663, 5451, 6181, 7049, -99],
+            [-99, -99, 1284, 2149, 3003, 3729, 4521, 5312, 6040, 6889, 7757, -99],
+            [-99, 1143, 2011, 2860, 3588, 4379, 5171, 5897, 6751, 7616, -99, -99],
+            [-99, 1851, 2719, 3449, 4237, 5029, 5756, 6609, 7473, -99, -99, -99],
+            [-99, -99, 3290, 4095, 4891, 5613, 6468, 7332, -99, -99, -99, -99],
+            [-99, -99, -99, 4731, 5472, 6330, 7189, -99, -99, -99, -99, -99],
+            [-99, -99, -99, -99, 6170, 7048, -99, -99, -99, -99, -99, -99],
+            [-99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99, -99],
+        ]
+    )
+    unmodified = original_image.copy()
+
+    # Note that the nodata values are not scaled (a previous bug!)
+    # they're translated to the output nodata value (0).
+
+    non = 0  # (Using a variable so the array is more spaced-out & readable)
+    expected_dynamic_rescale = np.array(
+        [
+            [non, non, non, non, non, non, non, non, non, non, non, non],
+            [non, non, non, non, non, non, 22, 58, non, non, non, non],
+            [non, non, non, non, non, 17, 51, 86, 116, non, non, non],
+            [non, non, non, non, 11, 46, 80, 109, 141, 174, non, non],
+            [non, non, non, 5, 40, 74, 104, 136, 167, 197, 232, non],
+            [non, non, non, 34, 69, 98, 130, 162, 191, 225, 255, non],
+            [non, non, 29, 63, 92, 124, 156, 185, 220, 255, non, non],
+            [non, 22, 57, 87, 118, 150, 180, 214, 249, non, non, non],
+            [non, non, 80, 113, 145, 174, 208, 243, non, non, non, non],
+            [non, non, non, 138, 168, 203, 237, non, non, non, non, non],
+            [non, non, non, non, 196, 232, non, non, non, non, non, non],
+            [non, non, non, non, non, non, non, non, non, non, non, non],
+        ],
+        dtype=np.uint8,
+    )
+
+    dynamically_rescaled = images.rescale_intensity(original_image, image_nodata=-99)
+    print("Dynamically rescaled result: ")
+    print(repr(dynamically_rescaled))
+    assert np.array_equal(dynamically_rescaled, expected_dynamic_rescale)
+    assert np.array_equal(
+        original_image, unmodified
+    ), "rescale_intensity modified the input image"
+
+    staticly_rescaled = images.rescale_intensity(
+        original_image,
+        static_range=(4000, 6000),
+        out_range=(100, 255),
+        image_nodata=-99,
+    )
+    print("Statically rescaled result: ")
+    print(repr(staticly_rescaled))
+
+    # Notice how many will be clipped to the min (100) without falling into nodata.
+    expected_static_rescale = np.array(
+        [
+            [non, non, non, non, non, non, non, non, non, non, non, non],
+            [non, non, non, non, non, non, 100, 100, non, non, non, non],
+            [non, non, non, non, non, 100, 100, 100, 113, non, non, non],
+            [non, non, non, non, 100, 100, 100, 100, 162, 224, non, non],
+            [non, non, non, 100, 100, 100, 100, 151, 212, 255, 255, non],
+            [non, non, 100, 100, 100, 100, 140, 201, 255, 255, 255, non],
+            [non, 100, 100, 100, 100, 129, 190, 247, 255, 255, non, non],
+            [non, 100, 100, 100, 118, 179, 236, 255, 255, non, non, non],
+            [non, non, 100, 107, 169, 225, 255, 255, non, non, non, non],
+            [non, non, non, 156, 214, 255, 255, non, non, non, non, non],
+            [non, non, non, non, 255, 255, non, non, non, non, non, non],
+            [non, non, non, non, non, non, non, non, non, non, non, non],
+        ],
+        dtype=np.uint8,
+    )
+    assert np.array_equal(staticly_rescaled, expected_static_rescale)

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -196,7 +196,6 @@ def test_whole_wagl_package(
             "properties": {
                 "datetime": datetime(2016, 6, 28, 0, 2, 28, 624_635),
                 "dea:dataset_maturity": "final",
-                "dea:processing_level": "level-2",
                 "dtr:end_datetime": datetime(2016, 6, 28, 0, 2, 43, 114_771),
                 "dtr:start_datetime": datetime(2016, 6, 28, 0, 2, 14, 25815),
                 "eo:cloud_cover": 63.069_613_577_531_236,

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -124,6 +124,7 @@ def test_whole_wagl_package(
             "$schema": "https://schemas.opendatacube.org/dataset",
             # A stable ID is taken from the WAGL doc.
             "id": "787eb74c-e7df-43d6-b562-b796137330ae",
+            "label": "ga_ls8c_ard_3-0-0_092084_2016-06-28_final",
             "product": {
                 "href": "https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3",
                 "name": "ga_ls8c_ard_3",


### PR DESCRIPTION
- Removed the confusing fallback values from the minimal-package filename.
- Added options for creating the thumbnail: resampling and stretch.
- The default thumbnail stretch is now dynamic (min/max 2% values), as the previous static stretch values didn't suit anything other than ARD datasets.

Addressed issues from the feedback session:
- ARD now uses a slightly lighter static stretch (it is still not finalised -- an agreement must be made)
- Populate the 'label' field. It was pointed out in the feedback that label is always null. We left it out previously because its information is technically redundant, and can be created from other fields in the dataset. But it _is_ simpler to have a single string to print rather than building one (the method of which can differ per product). So I've put in a  label until a further decision is made. Our existing tools that use label (the cli tools, cubedash) will look nicer.
- Change default overview resampling to 'average' (from nearest). Set fmask to use mode resampling.