### PR TITLE
Reduce required dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   # The python gdal bindings version need to match the gdal version of the system
 - travis_retry pip install --upgrade pip cattrs
 - travis_retry pip install --upgrade pytest pytest-cov pycodestyle flake8 coveralls GDAL==1.10.0 rasterio[s3]
-- travis_retry pip install -e .[test]
+- travis_retry pip install -e .[all]
 - pip freeze
   # Either both set or none. See: https://github.com/mapbox/rasterio/issues/1494
 - '[ "${AWS_SECRET_ACCESS_KEY}" ] || unset AWS_ACCESS_KEY_ID'

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ invoke it manually by running `pre-commit run`
 
 `eo3-prepare`: Prepare ODC metadata from the commandline.
 
+Some preparers need the ancillary dependencies: `pip install .[ancillary]`
+
      $ eo3-prepare --help
     Usage: eo3-prepare [OPTIONS] COMMAND [ARGS]...
     
@@ -86,6 +88,8 @@ invoke it manually by running `pre-commit run`
 
 `eo3-package-wagl`: Convert and package WAGL HDF5 outputs.
 
+ Needs the wagl dependencies group: `pip install .[wagl]`
+     
      $ eo3-package-wagl --help
     Usage: eo3-package-wagl [OPTIONS] H5_FILE
     

--- a/eodatasets3/metadata/valid_region.py
+++ b/eodatasets3/metadata/valid_region.py
@@ -1,26 +1,32 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 
 import rasterio
 import rasterio.features
 import shapely.affinity
 import shapely.geometry
 import shapely.ops
-from rasterio.errors import RasterioIOError
-from scipy import ndimage
 
 _LOG = logging.getLogger(__name__)
 
 
-def safe_valid_region(images, mask_value=None):
-    try:
-        return valid_region(images, mask_value)
-    except (OSError, RasterioIOError):
-        return None
-
-
 def valid_region(images, mask_value=None):
+    """
+    Deprecated valid_region method.
+
+    Used by the legacy prepare scripts. Newer ones will
+    presumably use the DatasetAssembler api instead.
+    """
+    try:
+        from scipy import ndimage
+    except ImportError:
+        sys.stderr.write(
+            "eodatasets3 has not been installed with the ancillary extras. \n"
+            "    Try `pip install eodatasets3[ancillary]\n"
+        )
+        raise
     mask = None
 
     if not images:

--- a/eodatasets3/prepare/s2_l1c_aws_pds_prepare.py
+++ b/eodatasets3/prepare/s2_l1c_aws_pds_prepare.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 import uuid
 from pathlib import Path
 from typing import Tuple, List, Dict, Optional
@@ -33,10 +34,18 @@ import rasterio.features
 import shapely.affinity
 import shapely.geometry
 import shapely.ops
-import yaml
-from checksumdir import dirhash
-from osgeo import osr
 from rasterio.errors import RasterioIOError
+from ruamel import yaml
+
+try:
+    from checksumdir import dirhash
+    from osgeo import osr
+except ImportError:
+    sys.stderr.write(
+        "eodatasets3 has not been installed with the ancillary extras. \n"
+        "    Try `pip install eodatasets3[ancillary]\n"
+    )
+    raise
 
 os.environ["CPL_ZIP_ENCODING"] = "UTF-8"
 SRC_BUCKET = "sentinel-s2-l1c"

--- a/eodatasets3/prepare/s2_prepare_cophub_zip.py
+++ b/eodatasets3/prepare/s2_prepare_cophub_zip.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 import hashlib
 import logging
 import os
+import sys
 import uuid
 import zipfile
 from datetime import datetime
@@ -23,11 +24,19 @@ import rasterio.features
 import shapely.affinity
 import shapely.geometry
 import shapely.ops
-import yaml
-from osgeo import osr
 from rasterio.errors import RasterioIOError
+from ruamel import yaml
 
 from eodatasets3.utils import read_paths_from_file, ClickDatetime
+
+try:
+    from osgeo import osr
+except ImportError:
+    sys.stderr.write(
+        "eodatasets3 has not been installed with the ancillary extras. \n"
+        "    Try `pip install eodatasets3[ancillary]\n"
+    )
+    raise
 
 os.environ["CPL_ZIP_ENCODING"] = "UTF-8"
 

--- a/eodatasets3/utils.py
+++ b/eodatasets3/utils.py
@@ -1,12 +1,11 @@
 import enum
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Tuple
 
 import ciso8601
 import click
-from dateutil import tz
 
 
 class ItemProvider(enum.Enum):
@@ -60,7 +59,7 @@ def read_paths_from_file(listing: Path) -> Iterable[Path]:
 
 def default_utc(d: datetime) -> datetime:
     if d.tzinfo is None:
-        return d.replace(tzinfo=tz.tzutc())
+        return d.replace(tzinfo=timezone.utc)
     return d
 
 

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -9,6 +9,7 @@ for files.
 import contextlib
 import os
 import re
+import sys
 from datetime import timedelta, datetime
 from pathlib import Path
 from typing import List, Sequence, Optional, Iterable, Any, Tuple, Dict, Mapping
@@ -16,7 +17,6 @@ from uuid import UUID
 
 import attr
 import click
-import h5py
 import numpy
 import rasterio
 from affine import Affine
@@ -32,6 +32,15 @@ from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
 from eodatasets3.serialise import loads_yaml
 from eodatasets3.utils import default_utc
+
+try:
+    import h5py
+except ImportError:
+    sys.stderr.write(
+        "eodatasets3 has not been installed with the wagl extras. \n"
+        "    Try `pip install eodatasets3[wagl]\n"
+    )
+    raise
 
 POSSIBLE_PRODUCTS = ("nbar", "nbart", "lambertian", "sbt")
 DEFAULT_PRODUCTS = ("nbar", "nbart")

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # coding=utf-8
 
 import pathlib
+from itertools import chain
 
 from setuptools import setup, find_packages
 
@@ -25,6 +26,14 @@ tests_require = [
     "rio_cogeo",
 ]
 
+EXTRAS_REQUIRE = {
+    "test": tests_require,
+    # If packaging ard/wagl.
+    "wagl": ["h5py"],
+    # The (legacy) prepare scripts
+    "ancillary": ["scipy", "checksumdir", "netCDF4", "gdal"],
+}
+EXTRAS_REQUIRE["all"] = list(chain(EXTRAS_REQUIRE.values()))
 
 setup(
     name="eodatasets3",
@@ -45,26 +54,19 @@ setup(
         "attrs",
         "boltons",
         "cattrs",
-        "checksumdir",
         "ciso8601",
         "click",
-        "gdal",
-        "h5py",
         "jsonschema",
-        "netCDF4",
         "numpy",
         "pyproj",
-        "python-dateutil",
-        "PyYAML!=5.1",
         "rasterio",
         "ruamel.yaml",
-        "scipy",
         "shapely",
         "structlog",
         "xarray",
     ],
     tests_require=tests_require,
-    extras_require={"test": tests_require},
+    extras_require=EXTRAS_REQUIRE,
     entry_points="""
         [console_scripts]
         eo3-validate=eodatasets3.validate:run

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -4,7 +4,7 @@ from pprint import pformat, pprint
 from typing import Dict
 
 import rapidjson
-import yaml
+from ruamel import yaml
 from boltons.iterutils import remap
 from click.testing import CliRunner, Result
 from deepdiff import DeepDiff
@@ -33,7 +33,8 @@ def assert_same_as_file(expected_doc: Dict, generated_file: Path, ignore_fields=
 
     assert generated_file.exists(), f"Expected file to exist {generated_file.name}"
 
-    generated_doc = yaml.load(generated_file.open("r"))
+    with generated_file.open("r") as f:
+        generated_doc = yaml.load(f)
     for field in ignore_fields:
         del generated_doc[field]
 

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -3,7 +3,7 @@ from functools import partial
 from pathlib import Path
 from pprint import pformat
 
-import yaml
+from ruamel import yaml
 from deepdiff import DeepDiff
 
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare


### PR DESCRIPTION
The install should be simpler for users who only want to use the assembler
api.

- remove pyyaml and dateutil.
- make optional (only for packaging wagl or legacy stuff): h5py,
netCDF4, gdal, scipy, checksumdir

(h5py is especially a pain in some environments)

Lazy users can still `pip install .[all]` to get all dependencies. But the affected prepare scripts and packagers (eg. wagl.) are niche in their usage.