### PR TITLE
Minimal versions of some deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,12 +55,12 @@ setup(
     ],
     url="https://github.com/GeoscienceAustralia/eo-datasets",
     install_requires=[
-        "attrs",
+        "attrs>=18.1",  # 18.1 adds 'factory' syntactic sugar
         "boltons",
         "cattrs",
         "ciso8601",
         "click",
-        "jsonschema",
+        "jsonschema>=3",  # We want a Draft6Validator
         "numpy",
         "pyproj",
         "rasterio",


### PR DESCRIPTION
Old versions of `attrs` and `jsonschema` prevent eodatasets3 from even being imported.

Pip doesn't always check versions, but it's getting better and it's good to document these requirements.