### PR TITLE
Allow eo3-validate to validate against a product definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,15 @@ invoke it manually by running `pre-commit run`
      $ eo3-validate --help
     Usage: eo3-validate [OPTIONS] [PATHS]...
     
-      Validate an ODC document
+      Validate ODC dataset documents
+    
+      Paths can be both product and dataset documents, but each product must
+      come before its datasets to be matched against it.
     
     Options:
       -W, --warnings-as-errors  Fail if any warnings are produced
+      --thorough                Attempt to read the data/measurements, and check
+                                their properties match the product
       -q, --quiet               Only print problems, one per line
       --help                    Show this message and exit.
 

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -5,11 +5,10 @@ from uuid import UUID
 
 import affine
 import attr
-from ruamel.yaml.comments import CommentedMap
-from shapely.geometry.base import BaseGeometry
-
 from eodatasets3 import utils
 from eodatasets3.properties import StacPropertyView, EoFields
+from ruamel.yaml.comments import CommentedMap
+from shapely.geometry.base import BaseGeometry
 
 # TODO: these need discussion.
 DEA_URI_PREFIX = "https://collections.dea.ga.gov.au"
@@ -338,48 +337,3 @@ class DatasetDoc(EoFields):
     accessories: Dict[str, AccessoryDoc] = attr.ib(factory=CommentedMap)
 
     lineage: Dict[str, Sequence[UUID]] = attr.ib(factory=CommentedMap)
-
-
-def resolve_absolute_offset(
-    dataset_path: Path, offset: str, target_path: Optional[Path] = None
-) -> str:
-    """
-    Expand a filename (offset) relative to the dataset.
-
-    >>> external_metadata_loc = Path('/tmp/target-metadata.yaml')
-    >>> resolve_absolute_offset(
-    ...     Path('/tmp/great_test_dataset'),
-    ...     'band/my_great_band.jpg',
-    ...     external_metadata_loc,
-    ... )
-    '/tmp/great_test_dataset/band/my_great_band.jpg'
-    >>> resolve_absolute_offset(
-    ...     Path('/tmp/great_test_dataset.tar.gz'),
-    ...     'band/my_great_band.jpg',
-    ...     external_metadata_loc,
-    ... )
-    'tar:/tmp/great_test_dataset.tar.gz!band/my_great_band.jpg'
-    >>> resolve_absolute_offset(
-    ...     Path('/tmp/great_test_dataset.tar'),
-    ...     'band/my_great_band.jpg',
-    ... )
-    'tar:/tmp/great_test_dataset.tar!band/my_great_band.jpg'
-    >>> resolve_absolute_offset(
-    ...     Path('/tmp/MY_DATASET'),
-    ...     'band/my_great_band.jpg',
-    ...     Path('/tmp/MY_DATASET/ga-metadata.yaml'),
-    ... )
-    'band/my_great_band.jpg'
-    """
-    dataset_path = dataset_path.absolute()
-
-    if target_path:
-        # If metadata is stored inside the dataset, keep paths relative.
-        if str(target_path.absolute()).startswith(str(dataset_path)):
-            return offset
-    # Bands are inside a tar file
-
-    if ".tar" in dataset_path.suffixes:
-        return "tar:{}!{}".format(dataset_path, offset)
-    else:
-        return str(dataset_path / offset)

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 from pathlib import Path, PurePath
-from typing import Dict, Tuple, Text, IO, Union, Iterable
+from typing import Dict, Tuple, Text, IO, Union, Iterable, Mapping
 from uuid import UUID
 
 import attr
@@ -94,7 +94,7 @@ def _init_yaml() -> YAML:
     return yaml
 
 
-def dump_yaml(output_yaml: Path, *docs: Dict) -> None:
+def dump_yaml(output_yaml: Path, *docs: Mapping) -> None:
     if not output_yaml.name.lower().endswith(".yaml"):
         raise ValueError(
             "YAML filename doesn't end in *.yaml (?). Received {!r}".format(output_yaml)

--- a/eodatasets3/ui.py
+++ b/eodatasets3/ui.py
@@ -1,6 +1,6 @@
 import os
 import urllib.parse
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import urljoin
 from urllib.parse import urlparse
@@ -15,7 +15,7 @@ class PathPath(click.Path):
         return Path(super().convert(value, param, ctx))
 
 
-def uri_resolve(base: Union[str, PurePath], path: Optional[str]) -> str:
+def uri_resolve(base: Union[str, Path], path: Optional[str]) -> str:
     """
     Backport of datacube.utils.uris.uri_resolve()
     """
@@ -24,8 +24,8 @@ def uri_resolve(base: Union[str, PurePath], path: Optional[str]) -> str:
         if p.is_absolute():
             return p.as_uri()
 
-    if isinstance(base, PurePath):
-        base = base.as_uri()
+    if isinstance(base, Path):
+        base = base.absolute().as_uri()
     return urljoin(base, path)
 
 

--- a/eodatasets3/ui.py
+++ b/eodatasets3/ui.py
@@ -1,7 +1,7 @@
 import os
 import urllib.parse
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PurePath
+from typing import Optional, Union
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
@@ -15,7 +15,7 @@ class PathPath(click.Path):
         return Path(super().convert(value, param, ctx))
 
 
-def uri_resolve(base: str, path: Optional[str]) -> str:
+def uri_resolve(base: Union[str, PurePath], path: Optional[str]) -> str:
     """
     Backport of datacube.utils.uris.uri_resolve()
     """
@@ -24,6 +24,8 @@ def uri_resolve(base: str, path: Optional[str]) -> str:
         if p.is_absolute():
             return p.as_uri()
 
+    if isinstance(base, PurePath):
+        base = base.as_uri()
     return urljoin(base, path)
 
 
@@ -57,3 +59,4 @@ def register_scheme(*schemes):
 
 
 register_scheme("tar")
+register_scheme("s3")

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -183,10 +183,11 @@ def validate(
                     #
                     # (datasets differ when, for example, sensors go offline, or when there's on-disk
                     #  measurements like panchromatic that GA doesn't want in their product definitions)
-                    yield _info(
-                        "unspecified_measurement",
-                        f"Measurement {name} is not in the product",
-                    )
+                    if required_measurements:
+                        yield _info(
+                            "unspecified_measurement",
+                            f"Measurement {name} is not in the product",
+                        )
                 else:
                     expected_dtype = expected_measurement.dtype
                     band_dtype = ds.dtypes[band - 1]

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -194,16 +194,20 @@ def validate(
                     if expected_dtype != band_dtype:
                         yield _error(
                             "different_dtype",
-                            f"dtype mismatch for {name}: "
-                            f"product has dtype {expected_dtype!r}, dataset has {band_dtype!r}",
+                            f"{name} dtype: "
+                            f"product {expected_dtype!r} != dataset {band_dtype!r}",
                         )
 
                     # TODO: the nodata can also be a fill value, as mentioned by Kirill.
-                    if expected_measurement.nodata != ds.nodatavals[band - 1]:
+                    expected_nodata = expected_measurement.nodata
+                    ds_nodata = ds.nodatavals[band - 1]
+                    if expected_nodata != ds_nodata and not (
+                        _is_nan(expected_nodata) and _is_nan(ds_nodata)
+                    ):
                         yield _error(
                             "different_nodata",
-                            f"nodata mismatch for {name}: "
-                            f"product {expected_measurement.nodata!r} != dataset {ds.nodatavals[band - 1]!r}",
+                            f"{name} nodata: "
+                            f"product {expected_nodata !r} != dataset {ds_nodata !r}",
                         )
 
 

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -279,6 +279,7 @@ def _create_contiguity(
             f"oa:{product.lower()}_contiguity",
             contiguity,
             geobox,
+            nodata=255,
             overviews=None,
             expand_valid_data=False,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,14 +44,17 @@ def l1_ls8_folder(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def l1_ls8_dataset_path(l1_ls8_folder: Path, l1_ls8_dataset: DatasetDoc) -> Path:
+def l1_ls8_metadata_path(l1_ls8_folder: Path, l1_ls8_dataset: DatasetDoc) -> Path:
+    path = l1_ls8_folder / f"{l1_ls8_dataset.label}.odc-metadata.yaml"
+    serialise.dump_yaml(path, serialise.to_formatted_doc(l1_ls8_dataset))
+    return path
+
+
+@pytest.fixture
+def l1_ls8_dataset_path(l1_ls8_folder: Path, l1_ls8_metadata_path: Path) -> Path:
     """
     A prepared L1 dataset with an EO3 metadata file.
     """
-    serialise.dump_yaml(
-        l1_ls8_folder / "dataset.odc-metadata.yaml",
-        serialise.to_formatted_doc(l1_ls8_dataset),
-    )
     return l1_ls8_folder
 
 
@@ -114,6 +117,9 @@ def example_metadata(
     l1_ls7_tarball_md_expected: Dict,
     l1_ls8_folder_md_expected: Dict,
 ):
+    """
+    Test against arbitrary valid eo3 documents.
+    """
     which = request.param
     if which == "ls5":
         return l1_ls5_tarball_md_expected

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -120,10 +120,10 @@ def test_whole_wagl_package(
 
     # Verify the computed contiguity looks the same. (metadata fields will depend on it)
     [image] = expected_folder.rglob("*_oa_*nbar-contiguity.tif")
-    _assert_image(image, nodata=None, unique_pixel_counts={0: 1978, 1: 4184})
+    _assert_image(image, nodata=255, unique_pixel_counts={0: 1978, 1: 4184})
 
     [image] = expected_folder.rglob("*_oa_*nbart-contiguity.tif")
-    _assert_image(image, nodata=None, unique_pixel_counts={0: 1979, 1: 4183})
+    _assert_image(image, nodata=255, unique_pixel_counts={0: 1979, 1: 4183})
 
     assert_same_as_file(
         {

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -334,6 +334,7 @@ def test_complains_when_no_product(
     """When a product is specified, it will validate that the measurements match the product"""
     # Thorough checking should fail when there's no product provided
     eo_validator.thorough = True
+    eo_validator.record_informational_messages = True
     eo_validator.assert_invalid(l1_ls8_metadata_path, codes=["no_product"])
 
 


### PR DESCRIPTION
`eo3-validate` can now take product yamls along with the dataset yamls, and it will check the list of measurements match the product.
```
$ eo3-validate products/*.yaml samples/**/*.odc-metadata.yaml
ga_ls5t_ard_3-0-0_092084_2009-12-17_final.odc-metadata: ✓
ga_ls7e_ard_3-0-0_092084_2016-08-23_final.odc-metadata: ✓
ga_ls8c_ard_3-0-0_092084_2016-06-28_final.odc-metadata: ✓

ok: All good
$ 
```

(One catch: each product must be listed earlier than its datasets or it wont be found to match against)

There is also a `--thorough` flag which will also open the data (with rasterio) to verify that dtypes/nodata values/etc match the product.

```
$ eo3-validate --thorough products/*.yaml samples/**/*.odc-metadata.yaml
ga_ls5t_ard_3-0-0_092084_2009-12-17_final.odc-metadata: ✓
ga_ls7e_ard_3-0-0_092084_2016-08-23_final.odc-metadata: ✓
ga_ls8c_ard_3-0-0_092084_2016-06-28_final.odc-metadata:
- E	different_nodata	oa_combined_terrain_shadow nodata: product -999 != dataset None

failure: 1 error
$ 
```

(Output has colours too. But there's still room for improvement in the readability of everything)