### PR TITLE
Clean-up validator output, complain when nodata values are impossible

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -625,7 +625,7 @@ class DatasetAssembler(EoFields):
         )
 
         if validate_correctness:
-            for m in validate.validate(doc):
+            for m in validate.validate_dataset(doc):
                 if m.level in (Level.info, Level.warning):
                     warnings.warn(DatasetCompletenessWarning(m))
                 elif m.level == Level.error:

--- a/eodatasets3/ui.py
+++ b/eodatasets3/ui.py
@@ -29,6 +29,13 @@ def uri_resolve(base: Union[str, Path], path: Optional[str]) -> str:
     return urljoin(base, path)
 
 
+def bool_style(b, color=True) -> str:
+    if b:
+        return click.style("✓", fg=color and "green")
+    else:
+        return click.style("✗", fg=color and "yellow")
+
+
 def is_absolute(url):
     """
     >>> is_absolute('LC08_L1TP_108078_20151203_20170401_01_T1.TIF')

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -209,7 +209,7 @@ def validate_dataset(
                     if expected_nodata != ds_nodata and not (
                         _is_nan(expected_nodata) and _is_nan(ds_nodata)
                     ):
-                        yield _error(
+                        yield _info(
                             "different_nodata",
                             f"{name} nodata: "
                             f"product {expected_nodata !r} != dataset {ds_nodata !r}",

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -264,6 +264,9 @@ def numpy_value_fits_dtype(value, dtype):
     """
     dtype = np.dtype(dtype)
 
+    if value is None:
+        value = 0
+
     if _is_nan(value):
         return np.issubdtype(dtype, np.floating)
     else:

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -16,22 +16,21 @@ from typing import List, Sequence, Optional, Iterable, Any, Tuple, Dict, Mapping
 from uuid import UUID
 
 import attr
-import click
 import numpy
 import rasterio
 from affine import Affine
 from boltons.iterutils import get_path, PathAccessError
 from click import secho
-from rasterio import DatasetReader
-from rasterio.crs import CRS
-from rasterio.enums import Resampling
-
 from eodatasets3 import serialise, utils, images
 from eodatasets3.assemble import DatasetAssembler
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
 from eodatasets3.serialise import loads_yaml
+from eodatasets3.ui import bool_style
 from eodatasets3.utils import default_utc
+from rasterio import DatasetReader
+from rasterio.crs import CRS
+from rasterio.enums import Resampling
 
 try:
     import h5py
@@ -302,13 +301,6 @@ def _create_contiguity(
             )
 
 
-def _boolstyle(s):
-    if s:
-        return click.style("✓", fg="green")
-    else:
-        return click.style("✗", fg="yellow")
-
-
 @contextlib.contextmanager
 def do(name: str, heading=False, **fields):
     """
@@ -320,7 +312,7 @@ def do(name: str, heading=False, **fields):
 
     def val(v: Any):
         if isinstance(v, bool):
-            return _boolstyle(v)
+            return bool_style(v)
         if isinstance(v, Path):
             return repr(str(v))
         return repr(v)

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -224,7 +224,7 @@ def test_valid_with_product_doc(
     product = dict(
         name="wrong_product",
         metadata_type="eo3",
-        measurements=[dict(name="blue", dtype="uint8", nodata=-999)],
+        measurements=[dict(name="blue", dtype="uint8", nodata=255)],
     )
     eo_validator.assert_valid(product, l1_ls8_metadata_path)
 
@@ -256,14 +256,14 @@ def test_nodata_compare_with_product_doc(
     product = dict(
         name="wrong_product",
         metadata_type="eo3",
-        measurements=[dict(name="blue", dtype="uint16", nodata=-999)],
+        measurements=[dict(name="blue", dtype="uint16", nodata=255)],
     )
 
     # When thorough, the dtype and nodata are wrong
     eo_validator.thorough = True
     eo_validator.assert_invalid(product, l1_ls8_metadata_path)
     assert eo_validator.messages == {
-        "different_nodata": "blue nodata: product -999 != dataset None"
+        "different_nodata": "blue nodata: product 255 != dataset None"
     }
 
 
@@ -326,7 +326,7 @@ def test_missing_measurement_from_product(
     )
     eo_validator.assert_invalid(product, l1_ls8_metadata_path)
     assert eo_validator.messages == {
-        "missing_measurement": "Product wrong_product expects a measurement 'razzmatazz')"
+        "missing_measurement": "Product no_measurement expects a measurement 'razzmatazz')"
     }
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -84,15 +84,15 @@ class ValidateRunner:
         """
 
         def _read_message(line: str):
-            severity, code, *message = line.split("\t")
-            return code, "\t".join(message)
+            severity, code, *message = line.split()
+            return code, " ".join(message)
 
         return dict(
             _read_message(line)
             for line in self.result.stdout.split("\n")
             if line
-            and line.startswith("-")
-            and (self.record_informational_messages or not line.startswith("- I\t"))
+            and line.startswith("\t")
+            and (self.record_informational_messages or not line.startswith("\tI "))
         )
 
 


### PR DESCRIPTION
Example:
```bash
$  eo3-validate digitalearthau/config/eo3/products/*.yaml 
✗ ard_ls5.odc-product
	E unsuitable_nodata Measurement 'nbar_red' nodata -999 does not fit a uint16
✓ ard_ls7.odc-product
✓ ard_ls8.odc-product
✓ l1_ls5.odc-product
✓ l1_ls7.odc-product
✓ l1_ls8.odc-product

failure: 1 error
$
```