### PR TITLE
Always include fmask cloud-cover property

### DIFF
--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -250,14 +250,19 @@ def prepare_and_write(
     file_format = FileFormat.GeoTIFF
 
     # Assumed below.
+    projection_params = mtl_doc["projection_parameters"]
     if (
-        mtl_doc["projection_parameters"]["grid_cell_size_reflective"]
-        != mtl_doc["projection_parameters"]["grid_cell_size_thermal"]
+        "grid_cell_size_thermal" in projection_params
+        and "grid_cell_size_reflective" in projection_params
+        and (
+            projection_params["grid_cell_size_reflective"]
+            != projection_params["grid_cell_size_thermal"]
+        )
     ):
         raise NotImplementedError("reflective and thermal have different cell sizes")
     ground_sample_distance = min(
         value
-        for name, value in mtl_doc["projection_parameters"].items()
+        for name, value in projection_params.items()
         if name.startswith("grid_cell_size_")
     )
 

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -292,7 +292,10 @@ def prepare_and_write(
         p.processed = mtl_doc["metadata_file_info"]["file_date"]
         p.properties["odc:file_format"] = file_format
         p.properties["eo:gsd"] = ground_sample_distance
-        p.properties["eo:cloud_cover"] = mtl_doc["image_attributes"]["cloud_cover"]
+        cloud_cover = mtl_doc["image_attributes"]["cloud_cover"]
+        # Cloud cover is -1 when missing (such as TIRS-only data)
+        if cloud_cover != -1:
+            p.properties["eo:cloud_cover"] = cloud_cover
         p.properties["eo:sun_azimuth"] = mtl_doc["image_attributes"]["sun_azimuth"]
         p.properties["eo:sun_elevation"] = mtl_doc["image_attributes"]["sun_elevation"]
         p.properties["landsat:collection_number"] = usgs_collection_number

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -568,12 +568,12 @@ def _read_gqa_doc(p: DatasetAssembler, doc: Dict):
 
 def _read_fmask_doc(p: DatasetAssembler, doc: Dict):
     for name, value in doc["percent_class_distribution"].items():
+        # From Josh: fmask cloud cover trumps the L1 cloud cover.
         if name == "cloud":
-            # From Josh: fmask cloud cover trumps the L1 cloud cover.
             del p.properties[f"eo:cloud_cover"]
             p.properties[f"eo:cloud_cover"] = value
-        else:
-            p.properties[f"fmask:{name}"] = value
+
+        p.properties[f"fmask:{name}"] = value
 
     _take_software_versions(p, doc)
     p.extend_user_metadata("fmask", doc)

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -3,18 +3,18 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, Tuple
 
+import eodatasets3
 import numpy as np
 import pytest
 import rasterio
 from click.testing import CliRunner
+from eodatasets3.model import DatasetDoc
 from rasterio import DatasetReader
 from rasterio.enums import Compression
 from rio_cogeo import cogeo
-
-import eodatasets3
-from eodatasets3.model import DatasetDoc
-from tests import assert_file_structure
 from tests.integration.common import assert_same_as_file
+
+from tests import assert_file_structure
 
 h5py = pytest.importorskip(
     "h5py",
@@ -211,6 +211,7 @@ def test_whole_wagl_package(
                 "eo:sun_azimuth": 33.655_125_34,
                 "eo:sun_elevation": 23.988_361_72,
                 "fmask:clear": 32.735_343_657_403_305,
+                "fmask:cloud": 63.069_613_577_531_236,
                 "fmask:cloud_shadow": 4.139_470_857_647_722,
                 "fmask:snow": 0.005_053_323_801_138_007,
                 "fmask:water": 0.050_518_583_616_596_675,


### PR DESCRIPTION
Asked for in feedback register. Include an `fmask:cloud` field, even though it's the same as the `eo:cloud_cover` field. (it was confusing to people, and made code less clear.)

Also makes the grid cell size parameters optional, since they are optional in MTL files.