### PR TITLE
The wagl Gadi migration should bump the second version digit, not the third

### DIFF
--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -525,14 +525,18 @@ def package(
             p.producer = "ga.gov.au"
             p.product_family = "ard"
 
+            _read_wagl_metadata(p, granule_group)
+
             org_collection_number = utils.get_collection_number(
                 p.producer, p.properties["landsat:collection_number"]
             )
+
             # TODO: wagl's algorithm version should determine our dataset version number, right?
-            p.dataset_version = f"{org_collection_number}.0.1"
+            dataset_proc_version = p.processed.strftime("%Y%m%d")
+            # The '1' is after gadi software changes.
+            p.dataset_version = f"{org_collection_number}.1.{dataset_proc_version}"
             p.region_code = _extract_reference_code(p, granule.name)
 
-            _read_wagl_metadata(p, granule_group)
             _read_gqa_doc(p, granule.gqa_doc)
             _read_fmask_doc(p, granule.fmask_doc)
             if granule.tesp_doc:

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -61,42 +61,42 @@ def test_whole_wagl_package(
     assert_file_structure(
         expected_folder,
         {
-            "ga_ls8c_ard_3-0-1_092084_2016-06-28_final.odc-metadata.yaml": "",
-            "ga_ls8c_ard_3-0-1_092084_2016-06-28_final.proc-info.yaml": "",
-            "ga_ls8c_ard_3-0-1_092084_2016-06-28_final.sha1": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band01.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band02.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band03.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band04.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band05.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band06.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band07.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band08.tif": "",
-            "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_thumbnail.jpg": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band01.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band02.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band03.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band04.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band05.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band06.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band07.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band08.tif": "",
-            "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_thumbnail.jpg": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_azimuthal-exiting.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_azimuthal-incident.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_combined-terrain-shadow.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_exiting-angle.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_fmask.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_incident-angle.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_nbar-contiguity.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_nbart-contiguity.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_relative-azimuth.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_relative-slope.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_satellite-azimuth.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_satellite-view.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_solar-azimuth.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_solar-zenith.tif": "",
-            "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_time-delta.tif": "",
+            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.odc-metadata.yaml": "",
+            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.proc-info.yaml": "",
+            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.sha1": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band01.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band02.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band03.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band04.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band05.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band06.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band07.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band08.tif": "",
+            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band01.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band02.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band03.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band04.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band05.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band06.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band07.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band08.tif": "",
+            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-exiting.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-incident.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_combined-terrain-shadow.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_exiting-angle.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_fmask.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_incident-angle.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbar-contiguity.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbart-contiguity.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-slope.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-view.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-zenith.tif": "",
+            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_time-delta.tif": "",
         },
     )
     [output_metadata] = expected_folder.rglob("*.odc-metadata.yaml")
@@ -129,7 +129,7 @@ def test_whole_wagl_package(
             "$schema": "https://schemas.opendatacube.org/dataset",
             # A stable ID is taken from the WAGL doc.
             "id": "787eb74c-e7df-43d6-b562-b796137330ae",
-            "label": "ga_ls8c_ard_3-0-1_092084_2016-06-28_final",
+            "label": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final",
             "product": {
                 "href": "https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3",
                 "name": "ga_ls8c_ard_3",
@@ -239,7 +239,7 @@ def test_whole_wagl_package(
                 "landsat:landsat_scene_id": "LC80920842016180LGN01",
                 "landsat:wrs_path": 92,
                 "landsat:wrs_row": 84,
-                "odc:dataset_version": "3.0.1",
+                "odc:dataset_version": "3.1.20190711",
                 "odc:file_format": "GeoTIFF",
                 "odc:processing_datetime": datetime(2019, 7, 11, 23, 29, 29, 21245),
                 "odc:producer": "ga.gov.au",
@@ -248,113 +248,113 @@ def test_whole_wagl_package(
             },
             "measurements": {
                 "nbar_blue": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band02.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band02.tif"
                 },
                 "nbar_coastal_aerosol": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band01.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band01.tif"
                 },
                 "nbar_green": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band03.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band03.tif"
                 },
                 "nbar_nir": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band05.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band05.tif"
                 },
                 "nbar_panchromatic": {
                     "grid": "panchromatic",
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band08.tif",
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band08.tif",
                 },
                 "nbar_red": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band04.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band04.tif"
                 },
                 "nbar_swir_1": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band06.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band06.tif"
                 },
                 "nbar_swir_2": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_band07.tif"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band07.tif"
                 },
                 "nbart_blue": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band02.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band02.tif"
                 },
                 "nbart_coastal_aerosol": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band01.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band01.tif"
                 },
                 "nbart_green": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band03.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band03.tif"
                 },
                 "nbart_nir": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band05.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band05.tif"
                 },
                 "nbart_panchromatic": {
                     "grid": "panchromatic",
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band08.tif",
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band08.tif",
                 },
                 "nbart_red": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band04.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band04.tif"
                 },
                 "nbart_swir_1": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band06.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band06.tif"
                 },
                 "nbart_swir_2": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_band07.tif"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band07.tif"
                 },
                 "oa_azimuthal_exiting": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_azimuthal-exiting.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-exiting.tif"
                 },
                 "oa_azimuthal_incident": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_azimuthal-incident.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-incident.tif"
                 },
                 "oa_combined_terrain_shadow": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_combined-terrain-shadow.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_combined-terrain-shadow.tif"
                 },
                 "oa_exiting_angle": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_exiting-angle.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_exiting-angle.tif"
                 },
                 "oa_fmask": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_fmask.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_fmask.tif"
                 },
                 "oa_incident_angle": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_incident-angle.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_incident-angle.tif"
                 },
                 "oa_nbar_contiguity": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_nbar-contiguity.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbar-contiguity.tif"
                 },
                 "oa_nbart_contiguity": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_nbart-contiguity.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbart-contiguity.tif"
                 },
                 "oa_relative_azimuth": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_relative-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-azimuth.tif"
                 },
                 "oa_relative_slope": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_relative-slope.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-slope.tif"
                 },
                 "oa_satellite_azimuth": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_satellite-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-azimuth.tif"
                 },
                 "oa_satellite_view": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_satellite-view.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-view.tif"
                 },
                 "oa_solar_azimuth": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_solar-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-azimuth.tif"
                 },
                 "oa_solar_zenith": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_solar-zenith.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-zenith.tif"
                 },
                 "oa_time_delta": {
-                    "path": "ga_ls8c_oa_3-0-1_092084_2016-06-28_final_time-delta.tif"
+                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_time-delta.tif"
                 },
             },
             "accessories": {
                 "checksum:sha1": {
-                    "path": "ga_ls8c_ard_3-0-1_092084_2016-06-28_final.sha1"
+                    "path": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.sha1"
                 },
                 "metadata:processor": {
-                    "path": "ga_ls8c_ard_3-0-1_092084_2016-06-28_final.proc-info.yaml"
+                    "path": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.proc-info.yaml"
                 },
                 "thumbnail:nbar": {
-                    "path": "ga_ls8c_nbar_3-0-1_092084_2016-06-28_final_thumbnail.jpg"
+                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg"
                 },
                 "thumbnail:nbart": {
-                    "path": "ga_ls8c_nbart_3-0-1_092084_2016-06-28_final_thumbnail.jpg"
+                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg"
                 },
             },
             "lineage": {"level1": ["fb1c622e-90aa-50e8-9d5e-ad69db82d0f6"]},


### PR DESCRIPTION
Each metadata version number has three digits:  eg: "3.0.0".

The Previous PR bumped the third digit (ie. "3.0.1") for new gadi data. But the third digit is the version of each dataset, not the collection. It's intended to be bumped when a dataset is reprocessed.

This changes the bump for our gadi software change to be the second digit, ie: "3.1.0"

I'm also adding the processing day as the dataset version (ie. "3.1.20190711"), to match what's done for L1 and USGS datasets. Currently wagl packages do no tracking of the dataset version, so reprocesses will all have the same number. This is better default behaviour, and it is backwards compatible with existing datasets.
