### PR TITLE
Record scan-gap-interpolation in Landsat L1 metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,10 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.19.0
+      rev: v1.23.0
       hooks:
           - id: yamllint
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v2.4.0
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
       hooks:
           - id: flake8

--- a/eodatasets3/dataset.schema.yaml
+++ b/eodatasets3/dataset.schema.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: "http://json-schema.org/schema#"
+$schema: "http://json-schema.org/draft-07/schema#"
 "$id": https://schemas.opendatacube.org/dataset
 title: Dataset
 type: object

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -51,7 +51,11 @@ class GridSpec:
     transform: Affine
 
     crs: CRS = attr.ib(
-        metadata=dict(doc_exclude=True), default=None, hash=False, cmp=False
+        metadata=dict(doc_exclude=True),
+        default=None,
+        hash=False,
+        eq=False,
+        order=False,
     )
 
     @classmethod

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -332,15 +332,15 @@ def prepare_and_write(
 @click.command(help=__doc__)
 @click.option(
     "--output-base",
-    help="Write output into this directory instead of with the dataset",
+    help="Write metadata files into a directory instead of alongside each dataset",
     required=False,
     type=PathPath(exists=True, writable=True, dir_okay=True, file_okay=False),
 )
 @click.option(
     "--source",
     "source_telemetry",
-    help="Paths to the source telemtry data for all of the provided datasets"
-    "(either folder or metadata file)",
+    help="Path to the source telemetry data for all of the provided datasets"
+    "(either the folder or metadata file)",
     required=False,
     type=PathPath(exists=True),
 )
@@ -363,7 +363,7 @@ def prepare_and_write(
     "--newer-than",
     type=serialise.ClickDatetime(),
     default=None,
-    help="Only prepare files newer than this date",
+    help="Only process files newer than this date",
 )
 def main(
     output_base: Optional[Path],

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -45,6 +45,7 @@ _COPYABLE_MTL_FIELDS = [
             "geometric_rmse_verify",
         ),
     ),
+    ("projection_parameters", ("scan_gap_interpolation",)),
 ]
 
 # Static namespace to generate uuids for datacube indexing

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -180,6 +180,7 @@ _LANDSAT_EXTENDED_PROPS = {
     "landsat:image_quality_oli": None,
     "landsat:image_quality_tirs": None,
     "landsat:processing_software_version": None,
+    "landsat:scan_gap_interpolation": float,
     "landsat:station_id": None,
 }
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,19 +10,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import pytest
-
-# An annotation for marking slow tests.
-#
-# Unit tests shouldn't usually take more than 30ms – it harms the feasibility of running them constantly.
-# (preferably much less than 20ms... but we often write to the filesystem in tests, due to the nature of this codebase.)
-#
-# This allows users (and CI servers) to selectively only run the slow/fast tests.
-slow = pytest.mark.slow
-
-# Mark integration tests. For now, we run them with the slow tests.
-integration_test = slow
-
 
 def assert_same(o1, o2, prefix=""):
     """

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -33,7 +33,7 @@ def assert_same_as_file(expected_doc: Dict, generated_file: Path, ignore_fields=
     assert generated_file.exists(), f"Expected file to exist {generated_file.name}"
 
     with generated_file.open("r") as f:
-        generated_doc = yaml.load(f)
+        generated_doc = yaml.safe_load(f)
     for field in ignore_fields:
         del generated_doc[field]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -330,6 +330,7 @@ def l1_ls7_tarball_md_expected(
             "landsat:landsat_scene_id": "LE71040782013119ASA00",
             "landsat:processing_software_version": "LPGS_12.8.2",
             "landsat:station_id": "ASA",
+            "landsat:scan_gap_interpolation": 2.0,
             "landsat:wrs_path": 104,
             "landsat:wrs_row": 78,
         },

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -235,7 +235,7 @@ def test_dataset_no_measurements(tmp_path: Path):
         dataset_id, metadata_path = p.done()
 
     with metadata_path.open("r") as f:
-        doc = yaml.load(f)
+        doc = yaml.safe_load(f)
 
     assert doc["label"] == "chipmonk_sightings_2019", "Couldn't override label field"
 
@@ -253,7 +253,7 @@ def test_minimal_s1_dataset(tmp_path: Path):
         dataset_id, metadata_path = p.done()
 
     with metadata_path.open("r") as f:
-        doc = yaml.load(f)
+        doc = yaml.safe_load(f)
 
     assert doc["label"] == "s1ac_bck_2018-11-04", "Unexpected dataset label"
 


### PR DESCRIPTION
And bump pre-commit libraries, as the current version of flake8 is failing on some systems.