### PR TITLE
Updated wagl versioning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       hooks:
           - id: yamllint
     - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.9
+      # flake8 version should match .travis.yml
+      rev: 3.8.2
       hooks:
           - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ install:
 - export C_INCLUDE_PATH="/usr/include/gdal"
   # The python gdal bindings version need to match the gdal version of the system
 - travis_retry pip install --upgrade pip cattrs
-- travis_retry pip install --upgrade pytest pytest-cov pycodestyle flake8 coveralls GDAL==1.10.0 rasterio[s3]
+- travis_retry pip install --upgrade pytest pytest-cov coveralls GDAL==1.10.0 rasterio[s3]
+  # flake8 version should match .pre-commit-config.yaml
+- travis_retry pip install flake8==3.8.2
 - travis_retry pip install -e .[test]
 - pip freeze
   # Either both set or none. See: https://github.com/mapbox/rasterio/issues/1494

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -901,17 +901,17 @@ class DatasetAssembler(EoFields):
         except ValueError:
             ...
 
-        def shorten(l: List, line_length=60):
-            s = ", ".join(sorted(l))
-            if len(s) > line_length:
-                return f"{s[:line_length]}..."
+        def format_list(items: List, max_len=60):
+            s = ", ".join(sorted(items))
+            if len(s) > max_len:
+                return f"{s[:max_len]}..."
             return s
 
         return dedent(
             f"""
             Assembling {product_name or ''} ({status})
-            - {len(measurements)} measurements: {shorten(measurements)}
-            - {len(properties)} properties: {shorten(properties)}
+            - {len(measurements)} measurements: {format_list(measurements)}
+            - {len(properties)} properties: {format_list(properties)}
             Writing to {target}
         """
         )

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -359,7 +359,7 @@ class ComplicatedNamingConventions:
         ) or self.dataset.properties.get("landsat:landsat_scene_id")
         if not landsat_id:
             raise NotImplementedError(
-                f"TODO: Can only currently abbreviate instruments from landsat references."
+                "TODO: Can only currently abbreviate instruments from Landsat references."
             )
 
         return landsat_id[1].lower()

--- a/eodatasets3/prepare/s2_l1c_aws_pds_prepare.py
+++ b/eodatasets3/prepare/s2_l1c_aws_pds_prepare.py
@@ -12,7 +12,7 @@ in a format to be read by datacube.
 
 example usage:
 
-    eod-prepare s2-awspds\
+    eo3-prepare s2-awspds\
  S2A_OPER_PRD_MSIL1C_PDMC_20161017T123606_R018_V20161016T034742_20161016T034739\
  --output . --no-checksum
 """

--- a/eodatasets3/prepare/s2_prepare_cophub_zip.py
+++ b/eodatasets3/prepare/s2_prepare_cophub_zip.py
@@ -551,7 +551,7 @@ def _process_datasets(
     + """
 example usage:
 
-    eod-prepare s2-cophub S2A_OPER_PRD_MSIL1C_PDMC_20161017T123606_R018_V20161016T034742_20161016T034739.zip
+    eo3-prepare s2-cophub S2A_OPER_PRD_MSIL1C_PDMC_20161017T123606_R018_V20161016T034742_20161016T034739.zip
  --output . --no-checksum
 """
 )

--- a/eodatasets3/scripts/recompress.py
+++ b/eodatasets3/scripts/recompress.py
@@ -19,7 +19,6 @@ from contextlib import suppress
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from subprocess import call
 from typing import List, Iterable, Tuple, Callable, IO, Dict
 
 import click
@@ -172,8 +171,6 @@ def repackage_tar(
             raise RuntimeError(f"No output after a success? Expected {output_tar_path}")
 
         if clean_inputs:
-            # Be extra sure the new file was flushed to disk before we clean the original.
-            call("sync")
             log.info("input.cleanup")
             please_remove(input_path, excluding=output_tar_path)
     except Exception:

--- a/eodatasets3/utils.py
+++ b/eodatasets3/utils.py
@@ -117,7 +117,7 @@ def get_collection_number(producer: str, usgs_collection_number: int) -> int:
         if usgs_collection_number == 1:
             return 3
         else:
-            raise NotImplementedError(f"Unsupported GA collection number.")
+            raise NotImplementedError("Unsupported GA collection number.")
     raise NotImplementedError(
         f"Unsupported collection number mapping for org: {producer!r}"
     )

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -325,7 +325,7 @@ def validate_paths(
                 messages.append(
                     _warning(
                         "unknown_product",
-                        f"Cannot match dataset to product",
+                        "Cannot match dataset to product",
                         hint=f"Nothing matches {product_name!r}"
                         if product_name
                         else "No product name in dataset (TODO: field matching)",
@@ -336,7 +336,7 @@ def validate_paths(
                 ValidationMessage(
                     Level.error if thorough else Level.info,
                     "no_product",
-                    f"No product provided: validating dataset information alone",
+                    "No product provided: validating dataset information alone",
                 )
             )
 

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Package WAGL HDF5 Outputs
 
@@ -544,7 +543,7 @@ def package(
             _unpack_products(p, included_products, granule_group)
 
             if include_oa:
-                with do(f"Starting OA", heading=True):
+                with do("Starting OA", heading=True):
                     _unpack_observation_attributes(
                         p,
                         included_products,
@@ -592,8 +591,8 @@ def _read_fmask_doc(p: DatasetAssembler, doc: Dict):
     for name, value in doc["percent_class_distribution"].items():
         # From Josh: fmask cloud cover trumps the L1 cloud cover.
         if name == "cloud":
-            del p.properties[f"eo:cloud_cover"]
-            p.properties[f"eo:cloud_cover"] = value
+            del p.properties["eo:cloud_cover"]
+            p.properties["eo:cloud_cover"] = value
 
         p.properties[f"fmask:{name}"] = value
 

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -532,9 +532,8 @@ def package(
             )
 
             # TODO: wagl's algorithm version should determine our dataset version number, right?
-            dataset_proc_version = p.processed.strftime("%Y%m%d")
             # The '1' is after gadi software changes.
-            p.dataset_version = f"{org_collection_number}.1.{dataset_proc_version}"
+            p.dataset_version = f"{org_collection_number}.1.0"
             p.region_code = _extract_reference_code(p, granule.name)
 
             _read_gqa_doc(p, granule.gqa_doc)

--- a/tests/integration/h5downsample.py
+++ b/tests/integration/h5downsample.py
@@ -61,7 +61,7 @@ def downsample(input: Path, factor: int, anti_alias: bool):
 
             old_shape = old_image.shape
             if all(dim_size < factor for dim_size in old_shape):
-                info(f"Skipping")
+                info("Skipping")
                 continue
 
             attrs = dict(old_image.attrs.items())

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -113,7 +113,7 @@ def test_whole_wagl_package(
         if p != checksum_file
     )
     files_in_checksum = {
-        Path(l.split("\t")[1]) for l in checksum_file.read_text().splitlines()
+        Path(line.split("\t")[1]) for line in checksum_file.read_text().splitlines()
     }
     assert all_output_files == files_in_checksum
 

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -61,42 +61,42 @@ def test_whole_wagl_package(
     assert_file_structure(
         expected_folder,
         {
-            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.odc-metadata.yaml": "",
-            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.proc-info.yaml": "",
-            "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.sha1": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band01.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band02.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band03.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band04.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band05.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band06.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band07.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band08.tif": "",
-            "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band01.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band02.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band03.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band04.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band05.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band06.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band07.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band08.tif": "",
-            "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-exiting.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-incident.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_combined-terrain-shadow.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_exiting-angle.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_fmask.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_incident-angle.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbar-contiguity.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbart-contiguity.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-azimuth.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-slope.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-azimuth.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-view.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-azimuth.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-zenith.tif": "",
-            "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_time-delta.tif": "",
+            "ga_ls8c_ard_3-1-0_092084_2016-06-28_final.odc-metadata.yaml": "",
+            "ga_ls8c_ard_3-1-0_092084_2016-06-28_final.proc-info.yaml": "",
+            "ga_ls8c_ard_3-1-0_092084_2016-06-28_final.sha1": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band01.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band02.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band03.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band04.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band05.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band06.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band07.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band08.tif": "",
+            "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_thumbnail.jpg": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band01.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band02.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band03.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band04.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band05.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band06.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band07.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band08.tif": "",
+            "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_thumbnail.jpg": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_azimuthal-exiting.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_azimuthal-incident.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_combined-terrain-shadow.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_exiting-angle.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_fmask.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_incident-angle.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_nbar-contiguity.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_nbart-contiguity.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_relative-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_relative-slope.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_satellite-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_satellite-view.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_solar-azimuth.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_solar-zenith.tif": "",
+            "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_time-delta.tif": "",
         },
     )
     [output_metadata] = expected_folder.rglob("*.odc-metadata.yaml")
@@ -129,7 +129,7 @@ def test_whole_wagl_package(
             "$schema": "https://schemas.opendatacube.org/dataset",
             # A stable ID is taken from the WAGL doc.
             "id": "787eb74c-e7df-43d6-b562-b796137330ae",
-            "label": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final",
+            "label": "ga_ls8c_ard_3-1-0_092084_2016-06-28_final",
             "product": {
                 "href": "https://collections.dea.ga.gov.au/product/ga_ls8c_ard_3",
                 "name": "ga_ls8c_ard_3",
@@ -239,7 +239,7 @@ def test_whole_wagl_package(
                 "landsat:landsat_scene_id": "LC80920842016180LGN01",
                 "landsat:wrs_path": 92,
                 "landsat:wrs_row": 84,
-                "odc:dataset_version": "3.1.20190711",
+                "odc:dataset_version": "3.1.0",
                 "odc:file_format": "GeoTIFF",
                 "odc:processing_datetime": datetime(2019, 7, 11, 23, 29, 29, 21245),
                 "odc:producer": "ga.gov.au",
@@ -248,113 +248,113 @@ def test_whole_wagl_package(
             },
             "measurements": {
                 "nbar_blue": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band02.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band02.tif"
                 },
                 "nbar_coastal_aerosol": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band01.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band01.tif"
                 },
                 "nbar_green": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band03.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band03.tif"
                 },
                 "nbar_nir": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band05.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band05.tif"
                 },
                 "nbar_panchromatic": {
                     "grid": "panchromatic",
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band08.tif",
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band08.tif",
                 },
                 "nbar_red": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band04.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band04.tif"
                 },
                 "nbar_swir_1": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band06.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band06.tif"
                 },
                 "nbar_swir_2": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_band07.tif"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_band07.tif"
                 },
                 "nbart_blue": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band02.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band02.tif"
                 },
                 "nbart_coastal_aerosol": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band01.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band01.tif"
                 },
                 "nbart_green": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band03.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band03.tif"
                 },
                 "nbart_nir": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band05.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band05.tif"
                 },
                 "nbart_panchromatic": {
                     "grid": "panchromatic",
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band08.tif",
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band08.tif",
                 },
                 "nbart_red": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band04.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band04.tif"
                 },
                 "nbart_swir_1": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band06.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band06.tif"
                 },
                 "nbart_swir_2": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_band07.tif"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_band07.tif"
                 },
                 "oa_azimuthal_exiting": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-exiting.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_azimuthal-exiting.tif"
                 },
                 "oa_azimuthal_incident": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_azimuthal-incident.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_azimuthal-incident.tif"
                 },
                 "oa_combined_terrain_shadow": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_combined-terrain-shadow.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_combined-terrain-shadow.tif"
                 },
                 "oa_exiting_angle": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_exiting-angle.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_exiting-angle.tif"
                 },
                 "oa_fmask": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_fmask.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_fmask.tif"
                 },
                 "oa_incident_angle": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_incident-angle.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_incident-angle.tif"
                 },
                 "oa_nbar_contiguity": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbar-contiguity.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_nbar-contiguity.tif"
                 },
                 "oa_nbart_contiguity": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_nbart-contiguity.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_nbart-contiguity.tif"
                 },
                 "oa_relative_azimuth": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_relative-azimuth.tif"
                 },
                 "oa_relative_slope": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_relative-slope.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_relative-slope.tif"
                 },
                 "oa_satellite_azimuth": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_satellite-azimuth.tif"
                 },
                 "oa_satellite_view": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_satellite-view.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_satellite-view.tif"
                 },
                 "oa_solar_azimuth": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-azimuth.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_solar-azimuth.tif"
                 },
                 "oa_solar_zenith": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_solar-zenith.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_solar-zenith.tif"
                 },
                 "oa_time_delta": {
-                    "path": "ga_ls8c_oa_3-1-20190711_092084_2016-06-28_final_time-delta.tif"
+                    "path": "ga_ls8c_oa_3-1-0_092084_2016-06-28_final_time-delta.tif"
                 },
             },
             "accessories": {
                 "checksum:sha1": {
-                    "path": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.sha1"
+                    "path": "ga_ls8c_ard_3-1-0_092084_2016-06-28_final.sha1"
                 },
                 "metadata:processor": {
-                    "path": "ga_ls8c_ard_3-1-20190711_092084_2016-06-28_final.proc-info.yaml"
+                    "path": "ga_ls8c_ard_3-1-0_092084_2016-06-28_final.proc-info.yaml"
                 },
                 "thumbnail:nbar": {
-                    "path": "ga_ls8c_nbar_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg"
+                    "path": "ga_ls8c_nbar_3-1-0_092084_2016-06-28_final_thumbnail.jpg"
                 },
                 "thumbnail:nbart": {
-                    "path": "ga_ls8c_nbart_3-1-20190711_092084_2016-06-28_final_thumbnail.jpg"
+                    "path": "ga_ls8c_nbart_3-1-0_092084_2016-06-28_final_thumbnail.jpg"
                 },
             },
             "lineage": {"level1": ["fb1c622e-90aa-50e8-9d5e-ad69db82d0f6"]},

--- a/tests/integration/test_recompress.py
+++ b/tests/integration/test_recompress.py
@@ -136,7 +136,7 @@ def test_recompress_gap_mask_dataset(tmp_path: Path):
 
     assert (
         len(all_output_files) == 1
-    ), f"Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    ), "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
     assert all_output_files == [str(expected_output)]
 
     assert (
@@ -219,7 +219,7 @@ def test_recompress_dirty_dataset(tmp_path: Path):
 
     assert (
         len(all_output_files) == 1
-    ), f"Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    ), "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
     assert all_output_files == [str(expected_output)]
 
     assert (

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -39,7 +39,7 @@ class ValidateRunner:
 
         if expect_no_messages and self.messages:
             raise AssertionError(
-                f"Expected no messages. Got: "
+                "Expected no messages. Got: "
                 + "\n".join(f"{k}: {v}" for k, v in self.messages.items())
             )
 
@@ -49,7 +49,7 @@ class ValidateRunner:
         assert (
             self.result.exit_code != 0
         ), f"Expected validation to fail.\n{self.result.output}"
-        assert self.result.exit_code == 1, f"Expected error code 1 for 1 invalid path"
+        assert self.result.exit_code == 1, "Expected error code 1 for 1 invalid path"
 
         if codes is not None:
             assert sorted(codes) == sorted(self.messages.keys())


### PR DESCRIPTION
As discussed among @simonaoliver, @sixy6e 

Includes updated tests.

There's also an old commit here from May to remove a `sync` call in the recompressor. `sync` is  *extremely* expensive on gadi and not necessary here.