### PR TITLE
Support for image "layer" when creating measurement record

### DIFF
--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -19,6 +19,7 @@ ODC_DATASET_SCHEMA_URL = "https://schemas.opendatacube.org/dataset"
 class FileFormat(Enum):
     GeoTIFF = 1
     NetCDF = 2
+    Zarr = 3
 
 
 # Either a local filesystem path or a string URI.


### PR DESCRIPTION
Hello,

Currently, using `MeasurementRecord.record_image()` to assemble measurements for an EO3 metadata file does not support hierarchical data formats that use the `"layer"` property.  This PR add this in, trying to touch as little of everything else as possible.

We are looking to use this mostly with `Zarr` formats but it would also be needed for e.g. `NetCDF`.

Cheers,

Dave
