### PR TITLE
Enable comparison of file format string against Enum

### DIFF
--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -51,7 +51,7 @@ class GridSpec:
     transform: Affine
 
     crs: CRS = attr.ib(
-        metadata=dict(doc_exclude=True), default=None, hash=False, cmp=False
+        metadata=dict(doc_exclude=True), default=None, hash=False, eq=False
     )
 
     @classmethod

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -16,7 +16,8 @@ import shapely.affinity
 import shapely.ops
 import xarray
 from affine import Affine
-from eodatasets3.model import GridDoc, MeasurementDoc, DatasetDoc, FileFormat
+from eodatasets3.model import GridDoc, MeasurementDoc, DatasetDoc
+from eodatasets3.properties import FileFormat
 from rasterio import DatasetReader
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Tuple, Dict, Optional, List, Sequence, Union
 from uuid import UUID
@@ -7,9 +6,10 @@ from uuid import UUID
 import affine
 import attr
 from eodatasets3 import utils
-from eodatasets3.properties import StacPropertyView, EoFields, FileFormat
+from eodatasets3.properties import StacPropertyView, EoFields
 from ruamel.yaml.comments import CommentedMap
 from shapely.geometry.base import BaseGeometry
+
 
 # TODO: these need discussion.
 DEA_URI_PREFIX = "https://collections.dea.ga.gov.au"

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -7,19 +7,13 @@ from uuid import UUID
 import affine
 import attr
 from eodatasets3 import utils
-from eodatasets3.properties import StacPropertyView, EoFields
+from eodatasets3.properties import StacPropertyView, EoFields, FileFormat
 from ruamel.yaml.comments import CommentedMap
 from shapely.geometry.base import BaseGeometry
 
 # TODO: these need discussion.
 DEA_URI_PREFIX = "https://collections.dea.ga.gov.au"
 ODC_DATASET_SCHEMA_URL = "https://schemas.opendatacube.org/dataset"
-
-
-class FileFormat(Enum):
-    GeoTIFF = 1
-    NetCDF = 2
-    Zarr = 3
 
 
 # Either a local filesystem path or a string URI.

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -17,7 +17,7 @@ from typing import List, Optional, Union, Iterable, Dict, Tuple, Callable, Gener
 import click
 import rasterio
 from eodatasets3 import serialise, utils, DatasetAssembler, IfExists
-from eodatasets3.model import FileFormat
+from eodatasets3.properties import FileFormat
 from eodatasets3.ui import PathPath
 
 _COPYABLE_MTL_FIELDS = [

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -3,12 +3,19 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from datetime import datetime
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import Tuple, Dict, Optional, Any, Mapping, Callable, Union
 
 import ciso8601
 from eodatasets3.utils import default_utc
+
 from ruamel.yaml.timestamp import TimeStamp as RuamelTimeStamp
+
+
+class FileFormat(Enum):
+    GeoTIFF = 1
+    NetCDF = 2
+    Zarr = 3
 
 
 def nest_properties(d: Mapping[str, Any], separator=":") -> Dict[str, Any]:
@@ -52,7 +59,12 @@ def datetime_type(value):
     return default_utc(value)
 
 
-def of_enum_type(vals: Tuple[str, ...] = None, lower=False, upper=False, strict=True):
+def of_enum_type(
+    vals: Union[EnumMeta, Tuple[str, ...]] = None, lower=False, upper=False, strict=True
+) -> Callable[[str], str]:
+    if isinstance(vals, EnumMeta):
+        vals = tuple(vals.__members__.keys())
+
     def normalise(v: str):
         if isinstance(v, Enum):
             v = v.name
@@ -215,7 +227,7 @@ class StacPropertyView(collections.abc.Mapping):
         "landsat:wrs_row": int,
         "odc:dataset_version": None,
         # Not strict as there may be more added in ODC...
-        "odc:file_format": of_enum_type(("GeoTIFF", "NetCDF"), strict=False),
+        "odc:file_format": of_enum_type(FileFormat, strict=False),
         "odc:processing_datetime": datetime_type,
         "odc:producer": producer_check,
         "odc:product_family": None,

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -15,11 +15,11 @@ import shapely.affinity
 import shapely.ops
 from affine import Affine
 from eodatasets3.model import (
-    FileFormat,
     DatasetDoc,
     ODC_DATASET_SCHEMA_URL,
     StacPropertyView,
 )
+from eodatasets3.properties import FileFormat
 from ruamel.yaml import YAML, ruamel, Representer
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from shapely.geometry import shape


### PR DESCRIPTION
Something minor that I missed in #83. 

This fixes a warning in our use of `eodatasets3`.