### PR TITLE
Add filter for valid polygons only in consume_and_get_valid_data()

### DIFF
--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -310,17 +310,23 @@ class MeasurementRecord:
 
         (they are consumed in order to to minimise peak memory usage)
         """
+
+        def valid_shape(shape):
+            if shape.is_valid:
+                return shape
+            return shape.buffer(0)
+
         geoms = []
         while self.mask_by_grid:
             grid, mask = self.mask_by_grid.popitem()
             mask = mask.astype("uint8")
-            shapes = [
-                shapely.geometry.shape(shape)
-                for shape, val in rasterio.features.shapes(mask)
-                if val == 1
-            ]
-            shapes = [shape for shape in shapes if shape.is_valid]
-            shape = shapely.ops.unary_union(shapes)
+            shape = shapely.ops.unary_union(
+                [
+                    valid_shape(shapely.geometry.shape(shape))
+                    for shape, val in rasterio.features.shapes(mask)
+                    if val == 1
+                ]
+            )
             shape_y, shape_x = mask.shape
             del mask
 

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -315,9 +315,9 @@ class MeasurementRecord:
             grid, mask = self.mask_by_grid.popitem()
             mask = mask.astype("uint8")
             shapes = [
-                    shapely.geometry.shape(shape)
-                    for shape, val in rasterio.features.shapes(mask)
-                    if val == 1
+                shapely.geometry.shape(shape)
+                for shape, val in rasterio.features.shapes(mask)
+                if val == 1
             ]
             shapes = [shape for shape in shapes if shape.is_valid]
             shape = shapely.ops.unary_union(shapes)

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -314,13 +314,13 @@ class MeasurementRecord:
         while self.mask_by_grid:
             grid, mask = self.mask_by_grid.popitem()
             mask = mask.astype("uint8")
-            shape = shapely.ops.unary_union(
-                [
+            shapes = [
                     shapely.geometry.shape(shape)
                     for shape, val in rasterio.features.shapes(mask)
                     if val == 1
-                ]
-            )
+            ]
+            shapes = [shape for shape in shapes if shape.is_valid]
+            shape = shapely.ops.unary_union(shapes)
             shape_y, shape_x = mask.shape
             del mask
 


### PR DESCRIPTION
We found some cases where
```
[
    shapely.geometry.shape(shape)
    for shape, val in rasterio.features.shapes(mask)
    if val == 1
]
```
creates invalid polygons. We haven't investigated why invalid polygons are created. Example scene is LE07_L1TP_124050_20170420_20170516_01_T1 processed to SR via ESPA.

This PR just introduces a filter to remove invalid polygons before passing to shapely.ops.unary_union().