### PR TITLE
Bump and Freeze Black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 ---
 repos:
     - repo: https://github.com/ambv/black
-      rev: 19.10b0
+      rev: 20.8b1
       hooks:
           - id: black
     - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.23.0
+      rev: v1.24.2
       hooks:
           - id: yamllint
     - repo: https://gitlab.com/pycqa/flake8
       # flake8 version should match .travis.yml
-      rev: 3.8.2
+      rev: 3.8.3
       hooks:
           - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   # The python gdal bindings version need to match the gdal version of the system
 - travis_retry pip install --upgrade pip cattrs
 - travis_retry pip install --upgrade pytest pytest-cov coveralls GDAL==1.10.0 rasterio[s3] 'scipy<1.5.0' pandas==1.0.5
-  # flake8 version should match .pre-commit-config.yaml
-- travis_retry pip install flake8==3.8.2
+  # flake8 and black versions should match .pre-commit-config.yaml
+- travis_retry pip install flake8==3.8.2 black==20.8b1
 - travis_retry pip install -e .[test]
 - pip freeze
   # Either both set or none. See: https://github.com/mapbox/rasterio/issues/1494

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -415,7 +415,7 @@ class FileWrite:
         compress="deflate",
         zlevel=4,
     ) -> "FileWrite":
-        """ Returns write_img options according to the source imagery provided
+        """Returns write_img options according to the source imagery provided
         :param overviews:
             (boolean) sets overview flags in gdal config options
         :param blockxsize:

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -116,7 +116,7 @@ def add_lineage(lineage: Dict) -> Dict:
 
 def add_odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
     """
-        Add links for ODC product into a STAC Item
+    Add links for ODC product into a STAC Item
     """
     if explorer_base_url:
         return [
@@ -151,7 +151,10 @@ def add_odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
     nargs=-1,
 )
 def run(
-    odc_metadata_files: Iterable[Path], stac_base_url, explorer_base_url, validate,
+    odc_metadata_files: Iterable[Path],
+    stac_base_url,
+    explorer_base_url,
+    validate,
 ):
     for input_metadata in odc_metadata_files:
         dataset = serialise.from_path(input_metadata)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,21 +9,23 @@ from eodatasets3 import serialise
 from eodatasets3.model import DatasetDoc
 from eodatasets3.prepare.landsat_l1_prepare import normalise_nci_symlinks
 
-L71GT_TARBALL_PATH: Path = Path(
-    __file__
-).parent / "data" / "LE07_L1TP_104078_20130429_20161124_01_T1.tar"
+L71GT_TARBALL_PATH: Path = (
+    Path(__file__).parent / "data" / "LE07_L1TP_104078_20130429_20161124_01_T1.tar"
+)
 
-L5_TARBALL_PATH: Path = Path(
-    __file__
-).parent / "data" / "LT05_L1TP_090085_19970406_20161231_01_T1.tar.gz"
+L5_TARBALL_PATH: Path = (
+    Path(__file__).parent / "data" / "LT05_L1TP_090085_19970406_20161231_01_T1.tar.gz"
+)
 
-L8_INPUT_PATH: Path = Path(
-    __file__
-).parent / "data" / "LC08_L1TP_090084_20160121_20170405_01_T1"
+L8_INPUT_PATH: Path = (
+    Path(__file__).parent / "data" / "LC08_L1TP_090084_20160121_20170405_01_T1"
+)
 
-LS8_TELEMETRY_PATH: Path = Path(
-    __file__
-).parent / "data" / "LS8_OLITIRS_STD-MD_P00_LC80840720742017365LGN00_084_072-074_20180101T004644Z20180101T004824_1"
+LS8_TELEMETRY_PATH: Path = (
+    Path(__file__).parent
+    / "data"
+    / "LS8_OLITIRS_STD-MD_P00_LC80840720742017365LGN00_084_072-074_20180101T004644Z20180101T004824_1"
+)
 
 
 def path_offset(base: Path, offset: str):

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -9,9 +9,11 @@ from deepdiff import DeepDiff
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare
 from tests.integration.common import run_prepare_cli
 
-NCEP_PR_WTR_FILE: Path = Path(
-    __file__
-).parent.parent / "data" / "noaa_c_c_prwtreatm_1/pr_wtr.eatm.2018.test.nc"
+NCEP_PR_WTR_FILE: Path = (
+    Path(__file__).parent.parent
+    / "data"
+    / "noaa_c_c_prwtreatm_1/pr_wtr.eatm.2018.test.nc"
+)
 
 _diff = partial(DeepDiff, significant_digits=6)
 

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -24,13 +24,15 @@ h5py = pytest.importorskip(
 
 # This test dataset comes from running `tests/integration/h5downsample.py` on a real
 # wagl output.
-WAGL_INPUT_PATH: Path = Path(
-    __file__
-).parent / "data/wagl-input/LC80920842016180LGN01/LC80920842016180LGN01.wagl.h5"
+WAGL_INPUT_PATH: Path = (
+    Path(__file__).parent
+    / "data/wagl-input/LC80920842016180LGN01/LC80920842016180LGN01.wagl.h5"
+)
 # The matching Level1 metadata (produced by landsat_l1_prepare.py)
-L1_METADATA_PATH: Path = Path(
-    __file__
-).parent / "data/wagl-input/LC08_L1TP_092084_20160628_20170323_01_T1.yaml"
+L1_METADATA_PATH: Path = (
+    Path(__file__).parent
+    / "data/wagl-input/LC08_L1TP_092084_20160628_20170323_01_T1.yaml"
+)
 
 
 def test_whole_wagl_package(

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -13,7 +13,9 @@ from tests.integration.common import run_prepare_cli
 TO_STAC_DATA: Path = Path(__file__).parent.joinpath("data/tostac")
 ODC_METADATA_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
 STAC_TEMPLATE_FILE: str = "ga_ls_ard_3_stac_item.json"
-STAC_EXPECTED_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json"
+STAC_EXPECTED_FILE: str = (
+    "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json"
+)
 
 deep_diff = partial(DeepDiff, significant_digits=6)
 


### PR DESCRIPTION
Old tags should not fail when Black makes new releases, so we should freeze its version.