### PR TITLE
Further stac conversion improvements, tighten public api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ install:
 - travis_retry pip install --upgrade pytest pytest-cov coveralls GDAL==1.10.0 rasterio[s3] 'scipy<1.5.0' pandas==1.0.5
   # flake8 and black versions should match .pre-commit-config.yaml
 - travis_retry pip install flake8==3.8.2 black==20.8b1
+  # Cattrs removed Python 3.6 support in 1.1.0
+- travis_retry pip install cattrs==1.0.0
 - travis_retry pip install -e .[test]
 - pip freeze
   # Either both set or none. See: https://github.com/mapbox/rasterio/issues/1494

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -225,7 +225,7 @@ def dataset_as_stac_item(
 
     item_doc = dict(
         stac_version="1.0.0-beta.2",
-        stac_extensions=["eo", "projection", "view"],
+        stac_extensions=["eo", "projection"],
         type="Feature",
         id=dataset.id,
         bbox=wgs84_geometry.boundingbox,
@@ -283,6 +283,11 @@ def dataset_as_stac_item(
             *_odc_links(explorer_base_url, dataset),
         ],
     )
+
+    # To pass validation, only add 'view' extension when we're using it somewhere.
+    if any(k.startswith("view:") for k in item_doc["properties"].keys()):
+        item_doc["stac_extensions"].append("view")
+
     if do_validate:
         validate_stac(item_doc)
     return item_doc

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -76,7 +76,7 @@ def dc_to_stac(
     Backwards compatibility wrapper as some other projects started using this
     method of the script.
 
-    It's better to call eodatasets3.stac.dataset_as_stac_item() directly.
+    It's better to call eodatasets3.stac.to_stac_item() directly.
     """
 
     stac_destination_url = urljoin(stac_base_url, output_path.name)

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -1,158 +1,19 @@
 """
-Convert a new-style ODC metadata doc to a Stac Item. (BETA/Incomplete)
+Convert a new-style ODC metadata doc to a Stac Item.
 """
 import json
-import math
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Dict, List
-from uuid import UUID
+from typing import Iterable
 from urllib.parse import urljoin
+from uuid import UUID
 
 import click
-import mimetypes
-from requests_cache.core import CachedSession
-from jsonschema import validate
 
 from eodatasets3 import serialise
-from eodatasets3.model import DatasetDoc, GridDoc
+from eodatasets3.model import DatasetDoc
+from eodatasets3.stac import to_stac_item
 from eodatasets3.ui import PathPath
-from datacube.utils.geometry import Geometry, CRS
-
-
-# Mapping between EO3 field names and STAC properties object field names
-
-MAPPING_EO3_TO_STAC = {
-    "dtr:end_datetime": "end_datetime",
-    "dtr:start_datetime": "start_datetime",
-    "eo:gsd": "gsd",
-    "eo:instrument": "instruments",
-    "eo:platform": "platform",
-    "eo:constellation": "constellation",
-    "eo:off_nadir": "view:off_nadir",
-    "eo:azimuth": "view:azimuth",
-    "eo:sun_azimuth": "view:sun_azimuth",
-    "eo:sun_elevation": "view:sun_elevation",
-    "odc:processing_datetime": "created",
-}
-
-
-def _as_stac_instruments(value: str):
-    """
-    >>> _as_stac_instruments('TM')
-    ['tm']
-    >>> _as_stac_instruments('OLI')
-    ['oli']
-    >>> _as_stac_instruments('ETM+')
-    ['etm']
-    >>> _as_stac_instruments('OLI_TIRS')
-    ['oli', 'tirs']
-    """
-    return [i.strip("+-").lower() for i in value.split("_")]
-
-
-def _convert_value_to_stac_type(key: str, value):
-    """
-    Convert return type as per STAC specification
-    """
-    # In STAC spec, "instruments" have [String] type
-    if key == "eo:instrument":
-        return _as_stac_instruments(value)
-    else:
-        return value
-
-
-def _media_fields(path: Path) -> Dict:
-    """
-    Add media type of the asset object
-    """
-    mime_type = mimetypes.guess_type(path.name)[0]
-    if path.suffix == ".sha1":
-        return {"type": "text/plain"}
-    elif path.suffix == ".yaml":
-        return {"type": "text/yaml"}
-    elif mime_type:
-        if mime_type == "image/tiff":
-            return {"type": "image/tiff; application=geotiff"}
-        else:
-            return {"type": mime_type}
-    else:
-        return {}
-
-
-def _asset_roles_fields(asset_name: str) -> Dict:
-    """
-    Add roles of the asset object
-    """
-    if asset_name.startswith("thumbnail"):
-        return {"roles": ["thumbnail"]}
-    elif asset_name.startswith("metadata"):
-        return {"roles": ["metadata"]}
-    else:
-        return {}
-
-
-def _asset_title_fields(asset_name: str) -> Dict:
-    """
-    Add title of the asset object
-    """
-    if asset_name.startswith("thumbnail"):
-        return {"title": "Thumbnail image"}
-    else:
-        return {}
-
-
-def _proj_fields(grid: Dict[str, GridDoc], grid_name: str = "default") -> Dict:
-    """
-    Add fields of the STAC Projection (proj) Extension to a STAC Item
-    """
-    grid_doc = grid.get(grid_name)
-    if grid_doc:
-        return {
-            "proj:shape": grid_doc.shape,
-            "proj:transform": grid_doc.transform,
-        }
-    else:
-        return {}
-
-
-def _lineage_fields(lineage: Dict) -> Dict:
-    """
-    Add custom lineage field to a STAC Item
-    """
-    if lineage:
-        return {"odc:lineage": lineage}
-    else:
-        return {}
-
-
-def _odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
-    """
-    Add links for ODC product into a STAC Item
-    """
-    if explorer_base_url:
-        return [
-            {
-                "title": "ODC Product Overview",
-                "rel": "product_overview",
-                "type": "text/html",
-                "href": urljoin(explorer_base_url, f"product/{dataset.product.name}"),
-            },
-            {
-                "title": "ODC Dataset Overview",
-                "rel": "alternative",
-                "type": "text/html",
-                "href": urljoin(explorer_base_url, f"dataset/{dataset.id}"),
-            },
-            {
-                "rel": "parent",
-                "href": urljoin(
-                    explorer_base_url, f"/stac/collections/{dataset.product.name}"
-                ),
-            },
-        ]
-    else:
-        return []
 
 
 @click.command(help=__doc__)
@@ -170,9 +31,9 @@ def _odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
 )
 def run(
     odc_metadata_files: Iterable[Path],
-    stac_base_url,
-    explorer_base_url,
-    validate,
+    stac_base_url: str,
+    explorer_base_url: str,
+    validate: bool,
 ):
     for input_metadata in odc_metadata_files:
         dataset = serialise.from_path(input_metadata)
@@ -181,116 +42,17 @@ def run(
         output_path = input_metadata.with_name(f"{name}.stac-item.json")
 
         # Create STAC dict
-        item_doc = dataset_as_stac_item(
+        item_doc = dc_to_stac(
             dataset,
-            input_metadata_url=urljoin(stac_base_url, input_metadata.name),
-            output_url=urljoin(stac_base_url, output_path.name),
-            explorer_base_url=explorer_base_url,
-            do_validate=validate,
+            input_metadata,
+            output_path,
+            stac_base_url,
+            explorer_base_url,
+            validate,
         )
 
         with output_path.open("w") as f:
             json.dump(item_doc, f, indent=4, default=json_fallback)
-
-
-def dataset_as_stac_item(
-    dataset: DatasetDoc,
-    input_metadata_url: str,
-    output_url: str,
-    explorer_base_url: str,
-    do_validate: bool = False,
-) -> dict:
-    """
-    Creates a STAC document for the given ODC dataset
-    """
-
-    geom = Geometry(dataset.geometry, CRS(dataset.crs))
-    wgs84_geometry = geom.to_crs(CRS("epsg:4326"), math.inf)
-
-    properties = {
-        # This field is required to be present, even if null.
-        "proj:epsg": None,
-    }
-    crs = dataset.crs.lower()
-    if crs.startswith("epsg:"):
-        properties["proj:epsg"] = int(crs.lstrip("epsg:"))
-    else:
-        properties["proj:wkt2"] = dataset.crs
-
-    if dataset.label:
-        properties["title"] = dataset.label
-
-    # TODO: choose remote if there's multiple locations?
-    dataset_location = dataset.locations[0] if dataset.locations else output_url
-
-    item_doc = dict(
-        stac_version="1.0.0-beta.2",
-        stac_extensions=["eo", "projection"],
-        type="Feature",
-        id=dataset.id,
-        bbox=wgs84_geometry.boundingbox,
-        geometry=wgs84_geometry.json,
-        properties={
-            **{
-                MAPPING_EO3_TO_STAC.get(key, key): _convert_value_to_stac_type(key, val)
-                for key, val in dataset.properties.items()
-            },
-            "odc:product": dataset.product.name,
-            **_lineage_fields(dataset.lineage),
-            **properties,
-            **(_proj_fields(dataset.grids) if dataset.grids else {}),
-        },
-        # TODO: Currently assuming no name collisions.
-        assets={
-            **{
-                name: (
-                    {
-                        "eo:bands": [{"name": name}],
-                        **_media_fields(Path(m.path)),
-                        "roles": ["data"],
-                        "href": urljoin(dataset_location, m.path),
-                        **(
-                            _proj_fields(dataset.grids, m.grid) if dataset.grids else {}
-                        ),
-                    }
-                )
-                for name, m in dataset.measurements.items()
-            },
-            **{
-                name: (
-                    {
-                        **_asset_title_fields(name),
-                        **_media_fields(Path(m.path)),
-                        **_asset_roles_fields(name),
-                        "href": urljoin(dataset_location, m.path),
-                    }
-                )
-                for name, m in dataset.accessories.items()
-            },
-        },
-        links=[
-            {
-                "rel": "self",
-                "type": "application/json",
-                "href": output_url,
-            },
-            {
-                "title": "ODC Dataset YAML",
-                "rel": "odc_yaml",
-                "type": "text/yaml",
-                "href": input_metadata_url,
-            },
-            *_odc_links(explorer_base_url, dataset),
-        ],
-    )
-
-    # To pass validation, only add 'view' extension when we're using it somewhere.
-    if any(k.startswith("view:") for k in item_doc["properties"].keys()):
-        item_doc["stac_extensions"].append("view")
-
-    if do_validate:
-        validate_stac(item_doc)
-    return item_doc
 
 
 def json_fallback(o):
@@ -307,30 +69,27 @@ def json_fallback(o):
     )
 
 
-def validate_stac(item_doc: Dict):
-    # Validates STAC content against schema of STAC item and STAC extensions
-    stac_content = json.loads(json.dumps(item_doc, default=json_fallback))
-    schema_urls = [
-        f"https://schemas.stacspec.org/"
-        f"v{item_doc.get('stac_version')}"
-        f"/item-spec/json-schema/item.json#"
-    ]
-    for extension in item_doc.get("stac_extensions", []):
-        schema_urls.append(
-            f"https://schemas.stacspec.org/"
-            f"v{item_doc.get('stac_version')}"
-            f"/extensions/{extension}"
-            f"/json-schema/schema.json#"
-        )
+def dc_to_stac(
+    dataset: DatasetDoc,
+    input_metadata: Path,
+    output_path: Path,
+    stac_base_url: str,
+    explorer_base_url: str,
+    do_validate: bool,
+) -> dict:
+    """
+    Backwards compatibility wrapper as some other projects started using this
+    method of the script.
 
-    for schema_url in schema_urls:
-        # Caching downloaded Schemas which expires every 1 hour
-        requests = CachedSession(
-            "stac_schema_cache", backend="sqlite", expire_after=3600
-        )
-        r = requests.get(schema_url)
-        schema_json = r.json()
-        validate(stac_content, schema_json)
+    It's better to call eodatasets3.stac.dataset_as_stac_item() directly.
+    """
+    return to_stac_item(
+        dataset,
+        input_metadata_url=urljoin(stac_base_url, input_metadata.name),
+        output_url=urljoin(stac_base_url, output_path.name),
+        explorer_base_url=explorer_base_url,
+        do_validate=do_validate,
+    )
 
 
 if __name__ == "__main__":

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -78,15 +78,24 @@ def dc_to_stac(
 
     It's better to call eodatasets3.stac.dataset_as_stac_item() directly.
     """
+
+    stac_destination_url = urljoin(stac_base_url, output_path.name)
+
+    # Following previous behaviour -- fallback to the stac destination path.
+    dataset_location = (
+        dataset.locations[0] if dataset.locations else stac_destination_url
+    )
+
     doc = eo3stac.to_stac_item(
         dataset,
-        stac_item_destination_url=urljoin(stac_base_url, output_path.name),
+        stac_item_destination_url=stac_destination_url,
         # This is potentially surprising.
         #     We just assume that they're uploading the odc document to the
         #     same public folder (and with the same name.)
         #     But we need to keep it for backwards compatibility.
         odc_dataset_metadata_url=urljoin(stac_base_url, input_metadata.name),
         explorer_base_url=explorer_base_url,
+        dataset_location=dataset_location,
     )
     if do_validate:
         eo3stac.validate_item(doc)

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -12,7 +12,7 @@ import click
 
 from eodatasets3 import serialise
 from eodatasets3.model import DatasetDoc
-from eodatasets3.stac import to_stac_item
+import eodatasets3.stac as eo3stac
 from eodatasets3.ui import PathPath
 
 
@@ -83,13 +83,20 @@ def dc_to_stac(
 
     It's better to call eodatasets3.stac.dataset_as_stac_item() directly.
     """
-    return to_stac_item(
+    doc = eo3stac.to_stac_item(
         dataset,
-        input_metadata_url=urljoin(stac_base_url, input_metadata.name),
-        output_url=urljoin(stac_base_url, output_path.name),
+        stac_item_destination_url=urljoin(stac_base_url, output_path.name),
+        # This is potentially surprising.
+        #     We just assume that they're uploading the odc document to the
+        #     same public folder (and with the same name.)
+        #     But we need to keep it for backwards compatibility.
+        odc_dataset_metadata_url=urljoin(stac_base_url, input_metadata.name),
         explorer_base_url=explorer_base_url,
-        do_validate=do_validate,
     )
+    if do_validate:
+        eo3stac.validate_stac(doc)
+
+    return doc
 
 
 if __name__ == "__main__":

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -208,14 +208,14 @@ def dataset_as_stac_item(
     wgs84_geometry = geom.to_crs(CRS("epsg:4326"), math.inf)
 
     properties = {
-        # This field is required by the proj standard, even if null.
+        # This field is required to be present, even if null.
         "proj:epsg": None,
     }
     crs = dataset.crs.lower()
     if crs.startswith("epsg:"):
         properties["proj:epsg"] = int(crs.lstrip("epsg:"))
     else:
-        raise NotImplementedError("TODO: Only epsg crses currently supported")
+        properties["proj:wkt2"] = dataset.crs
 
     if dataset.label:
         properties["title"] = dataset.label

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -1,0 +1,275 @@
+"""
+Convert a new-style ODC metadata doc to a Stac Item. (BETA/Incomplete)
+"""
+import json
+import math
+import mimetypes
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import urljoin
+
+from datacube.utils.geometry import Geometry, CRS
+from jsonschema import validate
+from requests_cache.core import CachedSession
+
+from eodatasets3.model import DatasetDoc, GridDoc
+
+# Mapping between EO3 field names and STAC properties object field names
+
+MAPPING_EO3_TO_STAC = {
+    "dtr:end_datetime": "end_datetime",
+    "dtr:start_datetime": "start_datetime",
+    "eo:gsd": "gsd",
+    "eo:instrument": "instruments",
+    "eo:platform": "platform",
+    "eo:constellation": "constellation",
+    "eo:off_nadir": "view:off_nadir",
+    "eo:azimuth": "view:azimuth",
+    "eo:sun_azimuth": "view:sun_azimuth",
+    "eo:sun_elevation": "view:sun_elevation",
+    "odc:processing_datetime": "created",
+}
+
+
+def _as_stac_instruments(value: str):
+    """
+    >>> _as_stac_instruments('TM')
+    ['tm']
+    >>> _as_stac_instruments('OLI')
+    ['oli']
+    >>> _as_stac_instruments('ETM+')
+    ['etm']
+    >>> _as_stac_instruments('OLI_TIRS')
+    ['oli', 'tirs']
+    """
+    return [i.strip("+-").lower() for i in value.split("_")]
+
+
+def _convert_value_to_stac_type(key: str, value):
+    """
+    Convert return type as per STAC specification
+    """
+    # In STAC spec, "instruments" have [String] type
+    if key == "eo:instrument":
+        return _as_stac_instruments(value)
+    else:
+        return value
+
+
+def _media_fields(path: Path) -> Dict:
+    """
+    Add media type of the asset object
+    """
+    mime_type = mimetypes.guess_type(path.name)[0]
+    if path.suffix == ".sha1":
+        return {"type": "text/plain"}
+    elif path.suffix == ".yaml":
+        return {"type": "text/yaml"}
+    elif mime_type:
+        if mime_type == "image/tiff":
+            return {"type": "image/tiff; application=geotiff"}
+        else:
+            return {"type": mime_type}
+    else:
+        return {}
+
+
+def _asset_roles_fields(asset_name: str) -> Dict:
+    """
+    Add roles of the asset object
+    """
+    if asset_name.startswith("thumbnail"):
+        return {"roles": ["thumbnail"]}
+    elif asset_name.startswith("metadata"):
+        return {"roles": ["metadata"]}
+    else:
+        return {}
+
+
+def _asset_title_fields(asset_name: str) -> Dict:
+    """
+    Add title of the asset object
+    """
+    if asset_name.startswith("thumbnail"):
+        return {"title": "Thumbnail image"}
+    else:
+        return {}
+
+
+def _proj_fields(grid: Dict[str, GridDoc], grid_name: str = "default") -> Dict:
+    """
+    Add fields of the STAC Projection (proj) Extension to a STAC Item
+    """
+    grid_doc = grid.get(grid_name)
+    if grid_doc:
+        return {
+            "proj:shape": grid_doc.shape,
+            "proj:transform": grid_doc.transform,
+        }
+    else:
+        return {}
+
+
+def _lineage_fields(lineage: Dict) -> Dict:
+    """
+    Add custom lineage field to a STAC Item
+    """
+    if lineage:
+        return {"odc:lineage": lineage}
+    else:
+        return {}
+
+
+def _odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
+    """
+    Add links for ODC product into a STAC Item
+    """
+    if explorer_base_url:
+        return [
+            {
+                "title": "ODC Product Overview",
+                "rel": "product_overview",
+                "type": "text/html",
+                "href": urljoin(explorer_base_url, f"product/{dataset.product.name}"),
+            },
+            {
+                "title": "ODC Dataset Overview",
+                "rel": "alternative",
+                "type": "text/html",
+                "href": urljoin(explorer_base_url, f"dataset/{dataset.id}"),
+            },
+            {
+                "rel": "parent",
+                "href": urljoin(
+                    explorer_base_url, f"/stac/collections/{dataset.product.name}"
+                ),
+            },
+        ]
+    else:
+        return []
+
+
+def to_stac_item(
+    dataset: DatasetDoc,
+    input_metadata_url: str,
+    output_url: str,
+    explorer_base_url: str,
+    do_validate: bool = False,
+) -> dict:
+    """
+    Convert the given ODC Dataset into a Stac Item document
+    """
+
+    geom = Geometry(dataset.geometry, CRS(dataset.crs))
+    wgs84_geometry = geom.to_crs(CRS("epsg:4326"), math.inf)
+
+    properties = {
+        # This field is required to be present, even if null.
+        "proj:epsg": None,
+    }
+    crs = dataset.crs.lower()
+    if crs.startswith("epsg:"):
+        properties["proj:epsg"] = int(crs.lstrip("epsg:"))
+    else:
+        properties["proj:wkt2"] = dataset.crs
+
+    if dataset.label:
+        properties["title"] = dataset.label
+
+    # TODO: choose remote if there's multiple locations?
+    dataset_location = dataset.locations[0] if dataset.locations else output_url
+
+    item_doc = dict(
+        stac_version="1.0.0-beta.2",
+        stac_extensions=["eo", "projection"],
+        type="Feature",
+        id=dataset.id,
+        bbox=wgs84_geometry.boundingbox,
+        geometry=wgs84_geometry.json,
+        properties={
+            **{
+                MAPPING_EO3_TO_STAC.get(key, key): _convert_value_to_stac_type(key, val)
+                for key, val in dataset.properties.items()
+            },
+            "odc:product": dataset.product.name,
+            **_lineage_fields(dataset.lineage),
+            **properties,
+            **(_proj_fields(dataset.grids) if dataset.grids else {}),
+        },
+        # TODO: Currently assuming no name collisions.
+        assets={
+            **{
+                name: (
+                    {
+                        "eo:bands": [{"name": name}],
+                        **_media_fields(Path(m.path)),
+                        "roles": ["data"],
+                        "href": urljoin(dataset_location, m.path),
+                        **(
+                            _proj_fields(dataset.grids, m.grid) if dataset.grids else {}
+                        ),
+                    }
+                )
+                for name, m in dataset.measurements.items()
+            },
+            **{
+                name: (
+                    {
+                        **_asset_title_fields(name),
+                        **_media_fields(Path(m.path)),
+                        **_asset_roles_fields(name),
+                        "href": urljoin(dataset_location, m.path),
+                    }
+                )
+                for name, m in dataset.accessories.items()
+            },
+        },
+        links=[
+            {
+                "rel": "self",
+                "type": "application/json",
+                "href": output_url,
+            },
+            {
+                "title": "ODC Dataset YAML",
+                "rel": "odc_yaml",
+                "type": "text/yaml",
+                "href": input_metadata_url,
+            },
+            *_odc_links(explorer_base_url, dataset),
+        ],
+    )
+
+    # To pass validation, only add 'view' extension when we're using it somewhere.
+    if any(k.startswith("view:") for k in item_doc["properties"].keys()):
+        item_doc["stac_extensions"].append("view")
+
+    if do_validate:
+        validate_stac(item_doc)
+    return item_doc
+
+
+def validate_stac(item_doc: Dict):
+    # Validates STAC content against schema of STAC item and STAC extensions
+    stac_content = json.loads(json.dumps(item_doc))
+    schema_urls = [
+        f"https://schemas.stacspec.org/"
+        f"v{item_doc.get('stac_version')}"
+        f"/item-spec/json-schema/item.json#"
+    ]
+    for extension in item_doc.get("stac_extensions", []):
+        schema_urls.append(
+            f"https://schemas.stacspec.org/"
+            f"v{item_doc.get('stac_version')}"
+            f"/extensions/{extension}"
+            f"/json-schema/schema.json#"
+        )
+
+    for schema_url in schema_urls:
+        # Caching downloaded Schemas which expires every 1 hour
+        requests = CachedSession(
+            "stac_schema_cache", backend="sqlite", expire_after=3600
+        )
+        r = requests.get(schema_url)
+        schema_json = r.json()
+        validate(stac_content, schema_json)

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -158,15 +158,16 @@ def to_stac_item(
     """
     Convert the given ODC Dataset into a Stac Item document.
 
-    Note: You may want to call `validate_stac(item_doc)` on the outputs to find any
+    Note: You may want to call `validate_item(doc)` on the outputs to find any
     incomplete properties.
 
-    :param stac_item_destination_url: Public 'self' URL for the stac document
-    :param odc_dataset_metadata_url: Public URL for the original ODC dataset yaml document
-    :param explorer_base_url: An Explorer URL that includes this dataset. Optinoal, but useful
-                              URLs will be included.
+    :param stac_item_destination_url: Public 'self' URL where the stac document will be findable.
     :param dataset_location: Use this location instead of picking from dataset.locations
                              (for calculating relative band paths)
+    :param odc_dataset_metadata_url: Public URL for the original ODC dataset yaml document
+    :param explorer_base_url: An Explorer instance that contains this dataset.
+                              Will allow links to things such as the product definition.
+
     """
 
     geom = Geometry(dataset.geometry, CRS(dataset.crs))
@@ -276,18 +277,17 @@ def validate_item(
     """
     Validate a document against the Stac Item schema and its declared extensions
 
-    Requires an internet connection to fetch the relevant spec version,
-    but will cache it locally for repeated requests.
+    Requires an internet connection the first time to fetch the relevant specs,
+    but will cache them locally for repeated requests.
 
     :param item_doc:
     :param allow_cached_specs: Allow using a cached spec.
                               Disable to force-download the spec again.
-
-    :param schema_host: The host for stac schema download
     :param disallow_network_access: Only allow validation using cached specs.
-    :param log: Report human-readable progress/status to this function.
+    :param log: Callback for human-readable progress/status (eg: 'print').
+    :param schema_host: The host to download stac schemas from.
 
-    :raises NoAvailableSchemaError If cannot find a spec for the given Stac version+extentions
+    :raises NoAvailableSchemaError: When cannot find a spec for the given Stac version+extentions
     """
     item_doc = _normalise_doc(item_doc)
 

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -151,6 +151,7 @@ def _odc_links(explorer_base_url: str, dataset: DatasetDoc) -> List:
 def to_stac_item(
     dataset: DatasetDoc,
     stac_item_destination_url: str,
+    dataset_location: Optional[str] = None,
     odc_dataset_metadata_url: Optional[str] = None,
     explorer_base_url: Optional[str] = None,
 ) -> dict:
@@ -164,6 +165,8 @@ def to_stac_item(
     :param odc_dataset_metadata_url: Public URL for the original ODC dataset yaml document
     :param explorer_base_url: An Explorer URL that includes this dataset. Optinoal, but useful
                               URLs will be included.
+    :param dataset_location: Use this location instead of picking from dataset.locations
+                             (for calculating relative band paths)
     """
 
     geom = Geometry(dataset.geometry, CRS(dataset.crs))
@@ -184,7 +187,9 @@ def to_stac_item(
 
     # TODO: choose remote if there's multiple locations?
     # Without a dataset location, all paths will be relative.
-    dataset_location = dataset.locations[0] if dataset.locations else None
+    dataset_location = dataset_location or (
+        dataset.locations[0] if dataset.locations else None
+    )
 
     links = []
     if stac_item_destination_url:

--- a/tests/common.py
+++ b/tests/common.py
@@ -41,9 +41,7 @@ def assert_same_as_file(expected_doc: Dict, generated_file: Path, ignore_fields=
     expected_doc = dump_roundtrip(expected_doc)
     generated_doc = dump_roundtrip(generated_doc)
 
-    assert expected_doc == generated_doc, "\n".join(
-        format_doc_diffs(expected_doc, generated_doc)
-    )
+    assert_same(expected_doc, generated_doc)
 
 
 def run_prepare_cli(invoke_script, *args, expect_success=True) -> Result:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from tests.common import format_doc_diffs
+
+
+def pytest_assertrepr_compare(op, left, right):
+    """
+    Custom pytest error messages for large documents.
+
+    The default pytest dict==dict error messages are unreadable for
+    nested document-like dicts. (Such as our json and yaml docs!)
+
+    We just want to know which fields differ.
+
+    (this function is stolen from Datacube Explorer because it's neat)
+    """
+
+    def is_a_doc(o: object):
+        """
+        Is it a dict that's not printable on one line?
+        """
+        return isinstance(o, dict) and len(repr(o)) > 88
+
+    if is_a_doc(left) and is_a_doc(right) and op == "==":
+        return format_doc_diffs(left, right)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,7 +131,7 @@ def example_metadata(
         return l1_ls7_tarball_md_expected
     elif which == "ls8":
         return l1_ls8_folder_md_expected
-    assert False
+    raise AssertionError
 
 
 def expected_l1_ls8_folder(

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -116,7 +116,8 @@
         "eo:cloud_cover": 42.42102985910952,
         "gsd": 15.0,
         "instruments": [
-            "OLI_TIRS"
+            "oli",
+            "tirs"
         ],
         "platform": "landsat-8",
         "view:sun_azimuth": 34.22994171,
@@ -153,7 +154,7 @@
         "landsat:wrs_row": 80,
         "odc:dataset_version": "3.1.0",
         "odc:file_format": "GeoTIFF",
-        "odc:processing_datetime": "2020-06-18T07:07:06.303867Z",
+        "created": "2020-06-18T07:07:06.303867Z",
         "odc:producer": "ga.gov.au",
         "odc:product_family": "ard",
         "odc:region_code": "088080",
@@ -164,6 +165,7 @@
             ]
         },
         "proj:epsg": 32656,
+        "title": "ga_ls8c_ard_3-1-0_088080_2020-05-25_final",
         "proj:shape": [
             7841,
             7781
@@ -1053,22 +1055,26 @@
             "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
         },
         {
-            "title": "Source Dataset YAML",
+            "title": "ODC Dataset YAML",
             "rel": "odc_yaml",
             "type": "text/yaml",
             "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
         },
         {
-            "title": "Open Data Cube Product Overview",
+            "title": "ODC Product Overview",
             "rel": "product_overview",
             "type": "text/html",
             "href": "https://explorer.dev.dea.ga.gov.au/product/ga_ls8c_ard_3"
         },
         {
-            "title": "Open Data Cube Explorer",
+            "title": "ODC Dataset Overview",
             "rel": "alternative",
             "type": "text/html",
             "href": "https://explorer.dev.dea.ga.gov.au/dataset/2aa69fcf-aa55-4747-9d95-3652f9fe79b0"
+        },
+        {
+            "rel": "parent",
+            "href": "https://explorer.dev.dea.ga.gov.au/stac/collections/ga_ls8c_ard_3"
         }
     ]
 }

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -7,7 +7,7 @@ from ruamel import yaml
 from deepdiff import DeepDiff
 
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare
-from tests.integration.common import run_prepare_cli
+from tests.common import run_prepare_cli
 
 NCEP_PR_WTR_FILE: Path = (
     Path(__file__).parent.parent

--- a/tests/integration/prepare/test_prepare_landsat_l1.py
+++ b/tests/integration/prepare/test_prepare_landsat_l1.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Dict
 
 from eodatasets3.prepare import landsat_l1_prepare
-from tests.integration.common import check_prepare_outputs
-from tests.integration.common import run_prepare_cli
+from tests.common import check_prepare_outputs
+from tests.common import run_prepare_cli
 
 
 def test_prepare_l5_l1_usgs_tarball(

--- a/tests/integration/prepare/test_prepare_s2a_l1c_safe.py
+++ b/tests/integration/prepare/test_prepare_s2a_l1c_safe.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from eodatasets3.prepare import s2_prepare_cophub_zip
-from tests.integration.common import check_prepare_outputs
+from tests.common import check_prepare_outputs
 
 L1_ZIPFILE_PATH: Path = (
     Path(__file__).parent.parent

--- a/tests/integration/prepare/test_prepare_s2b_l1c_awspds.py
+++ b/tests/integration/prepare/test_prepare_s2b_l1c_awspds.py
@@ -2,7 +2,7 @@ import zipfile
 from pathlib import Path
 
 from eodatasets3.prepare import s2_l1c_aws_pds_prepare
-from tests.integration.common import check_prepare_outputs
+from tests.common import check_prepare_outputs
 
 L1_ZIPFILE_PATH: Path = (
     Path(__file__).parent.parent

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -11,7 +11,7 @@ from eodatasets3 import DatasetAssembler
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
 from tests import assert_file_structure
-from tests.integration.common import assert_same_as_file
+from tests.common import assert_same_as_file
 
 
 def test_dea_style_package(

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -11,7 +11,7 @@ from rio_cogeo import cogeo
 import eodatasets3
 from eodatasets3.model import DatasetDoc
 from tests import assert_file_structure
-from tests.integration.common import assert_same_as_file
+from tests.common import assert_same_as_file
 
 from . import assert_image
 

--- a/tests/integration/test_serialise.py
+++ b/tests/integration/test_serialise.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Dict
 
 from eodatasets3 import serialise
-from .common import assert_same, dump_roundtrip
+from tests.common import dump_roundtrip
 
 
 def test_valid_document_works(tmp_path: Path, example_metadata: Dict):
@@ -13,6 +13,6 @@ def test_valid_document_works(tmp_path: Path, example_metadata: Dict):
         serialise.to_doc(serialise.from_doc(generated_doc))
     )
 
-    assert_same(generated_doc, reserialised_doc)
+    assert generated_doc == reserialised_doc
 
     assert serialise.from_doc(generated_doc) == serialise.from_doc(reserialised_doc)

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -1,14 +1,11 @@
 import json
 import shutil
-from functools import partial
 from pathlib import Path
-from pprint import pformat
 
 import pytest
-from deepdiff import DeepDiff
 from eodatasets3 import serialise
 from eodatasets3.scripts import tostac
-from tests.integration.common import run_prepare_cli
+from tests.common import run_prepare_cli, assert_same
 
 TO_STAC_DATA: Path = Path(__file__).parent.joinpath("data/tostac")
 ODC_METADATA_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
@@ -16,8 +13,6 @@ STAC_TEMPLATE_FILE: str = "ga_ls_ard_3_stac_item.json"
 STAC_EXPECTED_FILE: str = (
     "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json"
 )
-
-deep_diff = partial(DeepDiff, significant_digits=6)
 
 
 def test_tostac(input_doc_folder: Path):
@@ -35,8 +30,7 @@ def test_tostac(input_doc_folder: Path):
 
     actual_doc = json.load(actual_stac_path.open())
     expected_doc = json.load(expected_stac_path.open())
-    doc_diff = deep_diff(expected_doc, actual_doc)
-    assert doc_diff == {}, pformat(doc_diff)
+    assert_same(expected_doc, actual_doc)
 
 
 def test_add_property(input_doc_folder: Path):


### PR DESCRIPTION
Expansion of the stac converter so it can be used from other projects.

- Use the stac `created` field instead of ODC's field name.
- Include dataset label as a 'title' property (perhaps there's a better option?)
- Separate the LS8 instruments, following the [spec example](https://github.com/radiantearth/stac-spec/blob/4988a40f6071666d345e4a1c5adc9a6338973769/item-spec/examples/landsat8-sample.json#L48-L51)
- Fall-back to WKT2 when dataset crs is not an epsg code.
- Allow custom URLs, location to be used for the output paths.

- Make all functions private except the main ones. Keep the public api small.
- Add a link to the parent stac collection in Explorer
