### PR TITLE
Update DEA naming conventions for non-final products 

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,23 @@ Some preparers need the ancillary dependencies: `pip install .[ancillary]`
       --with-oa / --no-oa             Include observation attributes (default:
                                       true)
       --help                          Show this message and exit.
+
+
+## Creating Releases
+
+```
+git fetch origin
+
+# Create a tag for the new version
+git tag eodatasets3-<version> origin/eodatasets3
+
+# Push it to main repository
+git push origin --tags
+
+# Create a wheel locally
+python3 setup.py sdist bdist_wheel
+
+# Upload it (Jeremy, Damien, Kirill have pypi ownership) 
+python3 -m twine upload  dist/*
+
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ the provenance, and the assembler can optionally copy any common metadata automa
       # Set our product information.
       # It's a GA product of "numerus-unus" ("the number one").
       p.producer = "ga.gov.au"
-      p.product_family = "blues"
+      p.product_family = "numerus-unus"
       p.dataset_version = "3.0.0"
 
       ...
@@ -116,10 +116,11 @@ of the current image::
       ...
 
 Note that the assembler will throw an error if the path lives outside
-the dataset (location), as they will be absolute rather than relative paths.
+the dataset (location), as this will require absolute paths.
 Relative paths are considered best-practice for Open Data Cube.
 
-You can allow absolute paths with a field on assembler construction :meth:`eodatasets3.DatasetAssembler.__init__`::
+You can allow absolute paths with a field on assembler construction
+:meth:`eodatasets3.DatasetAssembler.__init__`::
 
    with DatasetAssembler(
       dataset_location=usgs_level1,

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -236,6 +236,11 @@ class ComplicatedNamingConventions:
 
         parts.extend(f"{self.dataset.datetime:%Y/%m/%d}".split("/"))
 
+        # If it's not a final product, append the maturity to the folder.
+        maturity: str = self.dataset.properties.get("dea:dataset_maturity")
+        if maturity and maturity != "final":
+            parts[-1] = f"{parts[-1]}_{maturity}"
+
         if self.dataset_separator_field is not None:
             val = self.dataset.properties[self.dataset_separator_field]
             # TODO: choosable formatter?

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -402,6 +402,33 @@ def test_complain_about_missing_fields(tmp_path: Path, l1_ls8_folder: Path):
             )
 
 
+def test_dea_interim_folder_calculation(tmp_path: Path):
+    """
+    DEA Naming conventions should include maturity in the folder name
+    when it's not a 'final' dataset.
+    """
+    with DatasetAssembler(tmp_path, naming_conventions="dea") as p:
+        p.platform = "landsat-7"
+        p.instrument = "ETM+"
+        p.datetime = datetime(1998, 7, 30)
+        p.product_family = "frogs"
+        p.processed = "1999-11-20 00:00:53.152462Z"
+        p.maturity = "interim"
+        p.producer = "ga.gov.au"
+        p.properties["landsat:landsat_scene_id"] = "LE70930821999324EDC00"
+        p.dataset_version = "1.2.3"
+        p.region_code = "093082"
+
+        p.done()
+
+    [metadata_path] = tmp_path.rglob("*.odc-metadata.yaml")
+    calculated_path: Path = metadata_path.relative_to(tmp_path)
+    assert calculated_path == Path(
+        #                                  ⇩⇩⇩⇩⇩⇩⇩⇩ Adds interim flag
+        "ga_ls7e_frogs_1/093/082/1998/07/30_interim/ga_ls7e_frogs_1-2-3_093082_1998-07-30_interim.odc-metadata.yaml"
+    )
+
+
 def test_dea_c3_naming_conventions(tmp_path: Path):
     """
     A sample scene for Alchemist C3 processing that tests the naming conventions.


### PR DESCRIPTION
As requested by the C3 ARD people: interim datasets go in a different folder than
final datasets.

This is implemented as an expansion to the existing 'DEA' naming conventions rather
than a new naming convention as it doesn't modify existing (final) products.

(note that no existing tests are modified, as it maintains other DEA outputs unchanged)

```
                                 ⇩ final datasets have no flag
/ga_ls5t_ard_3/096/095/2000/10/01/ga_ls5t_nbart_3-0-0_096095_2000-10-01_final_band05.tif

                                 ⇩ interim datasets go in different interim folder
/ga_ls5t_ard_3/096/095/2000/10/01_interim/ga_ls5t_nbart_3-0-0_096095_2000-10-01_interim_band05.tif
```
---

Includes other minor fixes to the docs.