### PR TITLE
Add Option to Inherit the Valid Geometry from Source Datasets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM opendatacube/geobase:wheels as env_builder
+ARG py_env_path=/env
+ARG ENVIRONMENT=test
+
+COPY requirements*.txt /tmp/
+# RUN env-build-tool new /tmp/requirements.txt ${py_env_path}
+RUN if [ "$ENVIRONMENT" = "test" ] ; then \
+        env-build-tool new /tmp/requirements-test.txt ${py_env_path} ; \
+    else \
+        env-build-tool new /tmp/requirements.txt ${py_env_path} ; \
+    fi
+
+ENV PATH=${py_env_path}/bin:$PATH
+
+# Copy source code and install it
+RUN mkdir -p /code
+WORKDIR /code
+ADD . /code
+
+RUN pip install --use-feature=2020-resolver .
+
+# Build the production runner stage from here
+FROM opendatacube/geobase:runner
+
+ENV LC_ALL=C.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive \
+    SHELL=bash
+
+COPY --from=env_builder /env /env
+ENV PATH=/env/bin:$PATH
+
+#  # Environment can be whatever is supported by setup.py
+#  # so, either deployment, test
+#  ARG ENVIRONMENT=test
+#  RUN echo "Environment is: $ENVIRONMENT"
+#
+#  # Set up a nice workdir, and only copy the things we care about in
+#  ENV APPDIR=/code
+#  RUN mkdir -p $APPDIR
+#  WORKDIR $APPDIR
+#  ADD . $APPDIR
+#
+#  # These ENVIRONMENT flags make this a bit complex, but basically, if we are in dev
+#  # then we want to link the source (with the -e flag) and if we're in prod, we
+#  # want to delete the stuff in the /code folder to keep it simple.
+#  RUN if [ "$ENVIRONMENT" = "deployment" ] ; then rm -rf $APPDIR ; \
+#      else pip install --editable .[$ENVIRONMENT] ; \
+#      fi
+
+RUN python
+
+CMD ["python"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+.PHONY: docker-tests
+
+docker-tests:
+#	docker build -t eodatasets:test test.
+	docker run -it --rm --volume "${PWD}/tests":/tests eodatasets:test pytest --cov eodatasets --durations=5 /tests

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -163,6 +163,7 @@ class DatasetAssembler(EoFields):
         self._user_metadata = dict()
         self._software_versions: List[Dict] = []
         self._lineage: Dict[str, List[uuid.UUID]] = defaultdict(list)
+        self._inherited_geometry = None
 
         if naming_conventions == "default":
             self.names = ComplicatedNamingConventions(self)
@@ -317,6 +318,7 @@ class DatasetAssembler(EoFields):
         dataset: DatasetDoc,
         classifier: Optional[str] = None,
         auto_inherit_properties: bool = False,
+        inherit_geometry: bool = False,
     ):
         """
         Record a source dataset using its metadata document.
@@ -335,6 +337,9 @@ class DatasetAssembler(EoFields):
                            are used for different purposes. Such as having a second level1 dataset
                            that was used for QA (but is not this same scene).
 
+        :param inherit_geometry: Instead of re-calculating the valid bounds geometry based on the
+                            data, which can be very computationally expensive e.g. Landsat 7
+                            striped data, use the valid data geometry from this source dataset.
 
         See :func:`add_source_path` if you have a filepath reference instead of a document.
 
@@ -353,6 +358,8 @@ class DatasetAssembler(EoFields):
         self._lineage[classifier].append(dataset.id)
         if auto_inherit_properties:
             self._inherit_properties_from(dataset)
+        if inherit_geometry:
+            self._inherited_geometry = dataset.geometry
 
     def _inherit_properties_from(self, source_dataset: DatasetDoc):
         for name in self.INHERITABLE_PROPERTIES:
@@ -669,7 +676,10 @@ class DatasetAssembler(EoFields):
         if measurement_docs and sort_measurements:
             measurement_docs = dict(sorted(measurement_docs.items()))
 
-        valid_data = self._measurements.consume_and_get_valid_data()
+        if self._inherited_geometry:
+            valid_data = self._inherited_geometry
+        else:
+            valid_data = self._measurements.consume_and_get_valid_data()
         # Avoid the messiness of different empty collection types.
         # (to have a non-null geometry we'd also need non-null grids and crses)
         if valid_data.is_empty:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,18 @@
+-r requirements.txt
+black
+deepdiff
+flake8
+hypothesis
+mock
+pep8-naming
+pytest
+pytest-flake8
+pytest-cov
+python-rapidjson
+rio_cogeo
+sphinx-autodoc-typehints
+sphinx_rtd_theme
+scipy
+checksumdir
+netCDF4
+gdal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+numpy
+pyproj
+xarray
+datacube
+rasterio
+cattrs
+boltons
+jsonschema>=3
+ruamel.yaml
+ciso8601
+shapely
+structlog
+requests-cache
+click

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -462,3 +462,43 @@ def test_dea_c3_naming_conventions(tmp_path: Path):
         metadata_path_offset
         == "ga_ls_wo_3/1-6-0/090/081/1998/07/30/ga_ls_wo_3_090081_1998-07-30_interim.odc-metadata.yaml"
     )
+
+
+@pytest.mark.parametrize(
+    "inherit_geom",
+    [True, False],
+    ids=["inherit geom from dataset", "don't inherit geom"],
+)
+def test_add_source_dataset(tmp_path: Path, inherit_geom):
+    from eodatasets3 import serialise
+
+    p = DatasetAssembler(tmp_path, naming_conventions="dea_c3")
+    source_dataset = serialise.from_path(
+        Path(__file__).parent / "data/LC08_L1TP_089080_20160302_20170328_01_T1.yaml"
+    )
+    p.add_source_dataset(
+        source_dataset, auto_inherit_properties=True, inherit_geometry=inherit_geom
+    )
+
+    p.maturity = "interim"
+    p.collection_number = "3"
+    p.dataset_version = "1.6.0"
+    p.producer = "ga.gov.au"
+    p.processed = "1998-07-30T12:23:23"
+    p.product_family = "wofs"
+    p.write_measurement(
+        "water",
+        Path(__file__).parent
+        / "data/wofs/ga_ls_wofs_3_099081_2020-07-26_interim_water_clipped.tif",
+    )
+
+    id, path = p.done()
+
+    output = serialise.from_path(path)
+    if inherit_geom:
+        # POLYGON((609615 - 3077085, 378285 - 3077085, 378285 - 3310515, 609615 - 3310515, 609615 - 3077085))
+        assert output.geometry == source_dataset.geometry
+    else:
+        # POLYGON((684285 - 3439275, 684285 - 3444495, 689925 - 3444495, 689925 - 3439275, 684285 - 3439275))
+        # Geometry is not set from the source dataset, but instead from the added wofs measurement
+        assert output.geometry != source_dataset.geometry


### PR DESCRIPTION
While running some processing on derivative data, we discovered that in some cases 
it was taking upwards of an hour to perform the vector operations required to derive 
the valid data geometry.

In many cases it should be possible to copy the geometry from the input dataset and short
circuit the need to do any calculations at all.

This PR adds a flag to `.add_dataset_source()` called `inherit_geometry` which makes this
happen.

I've also added some files to ease testing, and perhaps move to new setup in CI. If Docker
is installed you can now run `make docker-test` which will build a new docker image and
run the tests against an installed version of **eo-datasets**.