### PR TITLE
Water atcor undo s2 naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
       hooks:
           - id: black
     - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.24.2
+      rev: v1.25.0
       hooks:
           - id: yamllint
     - repo: https://gitlab.com/pycqa/flake8
       # flake8 version should match .travis.yml
-      rev: 3.8.3
+      rev: 3.8.4
       hooks:
           - id: flake8

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -225,9 +225,7 @@ class ComplicatedNamingConventions:
     def destination_folder(self, base: Path):
         self._check_enough_properties_to_name()
         # DEA naming conventions folder hierarchy.
-        # Examples:
-        # For L8:    "ga_ls8c_aard_3/092/084/2016/06/28"
-        # For S2A/B: "ga_s2bm_aard_2/55/KDT/2016/06/28/003241"
+        # Example: "ga_ls8c_ard_3/092/084/2016/06/28"
 
         parts = [self.product_name]
 
@@ -236,16 +234,7 @@ class ComplicatedNamingConventions:
         if region_code:
             parts.extend(utils.subfolderise(region_code))
 
-        if self.dataset.platform:
-            # added to pass test_assemble.py, where self.dataset.platform = None
-            if self.dataset.platform.startswith("sentinel-2"):
-                # modified output dir so to include HHMMSS to account for
-                # multiple acquisitions per day
-                parts.extend(f"{self.dataset.datetime:%Y/%m/%d/%H%M%S}".split("/"))
-            else:
-                parts.extend(f"{self.dataset.datetime:%Y/%m/%d}".split("/"))
-        else:
-            parts.extend(f"{self.dataset.datetime:%Y/%m/%d}".split("/"))
+        parts.extend(f"{self.dataset.datetime:%Y/%m/%d}".split("/"))
 
         # If it's not a final product, append the maturity to the folder.
         maturity: str = self.dataset.properties.get("dea:dataset_maturity")

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -277,7 +277,7 @@ def test_minimal_s2_dataset_normal(tmp_path: Path):
         # A custom label too.
         p.platform = "sentinel-2a"
         p.instrument = "msi"
-        p.datetime = datetime(2018, 11, 4, 1, 11, 11)
+        p.datetime = datetime(2018, 11, 4)
         p.product_family = "blueberries"
         p.processed = "2018-11-05T12:23:23"
         p.properties[
@@ -291,7 +291,7 @@ def test_minimal_s2_dataset_normal(tmp_path: Path):
 
     metadata_path_offset = metadata_path.relative_to(tmp_path).as_posix()
     assert metadata_path_offset == (
-        "s2am_blueberries/2018/11/04/011111/s2am_blueberries_2018-11-04.odc-metadata.yaml"
+        "s2am_blueberries/2018/11/04/s2am_blueberries_2018-11-04.odc-metadata.yaml"
     )
 
     assert doc["label"] == "s2am_blueberries_2018-11-04", "Unexpected dataset label"
@@ -302,7 +302,7 @@ def test_s2_naming_conventions(tmp_path: Path):
     p = DatasetAssembler(tmp_path, naming_conventions="dea_s2")
     p.platform = "sentinel-2a"
     p.instrument = "msi"
-    p.datetime = datetime(2018, 11, 4, 1, 11, 11)
+    p.datetime = datetime(2018, 11, 4)
     p.product_family = "blueberries"
     p.processed = "2018-11-05T12:23:23"
     p.producer = "ga.gov.au"
@@ -324,7 +324,7 @@ def test_s2_naming_conventions(tmp_path: Path):
     metadata_path_offset = metadata_path.relative_to(tmp_path).as_posix()
 
     assert metadata_path_offset == (
-        "ga_s2am_blueberries_1/Oz/2018/11/04/011111/20170822T015626/"
+        "ga_s2am_blueberries_1/Oz/2018/11/04/20170822T015626/"
         "ga_s2am_blueberries_1-0-0_Oz_2018-11-04.odc-metadata.yaml"
     )
 
@@ -347,7 +347,7 @@ def test_s2_naming_conventions(tmp_path: Path):
                 "name": "ga_s2am_blueberries_1",
             },
             "properties": {
-                "datetime": datetime(2018, 11, 4, 1, 11, 11),
+                "datetime": datetime(2018, 11, 4, 0, 0, 0),
                 "eo:instrument": "msi",
                 "eo:platform": "sentinel-2a",
                 "odc:dataset_version": "1.0.0",

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -95,9 +95,6 @@ def test_whole_wagl_package(
         },
     )
     [output_metadata] = expected_folder.rglob("*.odc-metadata.yaml")
-    from pprint import pprint
-
-    pprint(output_metadata)
 
     assert reported_metadata == str(
         output_metadata


### PR DESCRIPTION
Very little work in the end.  A few minor unwindings as there was already an `dea_s2` naming spec defined.