### PR TITLE
Use rel=collection in stac, not rel=parent

### DIFF
--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -1061,6 +1061,10 @@
             "href": "http://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
         },
         {
+            "rel": "collection",
+            "href": "https://explorer.dev.dea.ga.gov.au/stac/collections/ga_ls8c_ard_3"
+        },
+        {
             "title": "ODC Product Overview",
             "rel": "product_overview",
             "type": "text/html",
@@ -1071,10 +1075,6 @@
             "rel": "alternative",
             "type": "text/html",
             "href": "https://explorer.dev.dea.ga.gov.au/dataset/2aa69fcf-aa55-4747-9d95-3652f9fe79b0"
-        },
-        {
-            "rel": "parent",
-            "href": "https://explorer.dev.dea.ga.gov.au/stac/collections/ga_ls8c_ard_3"
         }
     ]
 }


### PR DESCRIPTION
As is strongly encouraged by the spec: https://github.com/radiantearth/stac-spec/blob/4988a40f6071666d345e4a1c5adc9a6338973769/item-spec/item-spec.md#relation-types

Users can specify either a collection_url or an explorer_url to have the collection url added to their Item.

---
Includes an unrelated clean-up I had done previously (yes, this is unwise): move the stac property conversion logic into its own method.

