### PR TITLE
Loosen the rio constraint in setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG ENVIRONMENT=test
 COPY requirements*.txt /tmp/
 # RUN env-build-tool new /tmp/requirements.txt ${py_env_path}
 RUN if [ "$ENVIRONMENT" = "test" ] ; then \
+        rm /wheels/rasterio*whl ; \
         env-build-tool new /tmp/requirements-test.txt ${py_env_path} ; \
     else \
         env-build-tool new /tmp/requirements.txt ${py_env_path} ; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ numpy
 pyproj
 xarray
 datacube
-rasterio
+# Min needed for rio-cogeo (tests fail on import without it):
+rasterio==1.1.8
 cattrs
 boltons
 jsonschema>=3

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "jsonschema>=3",  # We want a Draft6Validator
         "numpy>=1.15.4",
         "pyproj",
-        "rasterio>=1.1.8",  # Seems needed for rio cogeo
+        "rasterio",
         "ruamel.yaml",
         "shapely",
         "structlog",


### PR DESCRIPTION
eo-datasets itself doesn't need the higher rio version, it was only added (50ab111b98198a61299c8f7d75e812645078b25a) as a workaround for rio-cogeo when running tests. So we should have it in requirements.txt, not setup.py

Geobase uses the previous version of rasterio, so it's painful to others if we make it a hard requirement.