### PR TITLE
Remove unnecessary read of images in note measurements 

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -617,7 +617,7 @@ class DatasetAssembler(EoFields):
                 name,
                 images.GridSpec.from_rio(ds),
                 path,
-                ds.read(1),
+                ds.read(1) if expand_valid_data else None,
                 nodata=ds.nodata,
                 expand_valid_data=expand_valid_data,
             )


### PR DESCRIPTION
This PR changes `DatasetAssembler.note_measurement` to not read the image file if the `expand_valid_data` parameter is `False`. This optimization reduces file IO which can be a bottleneck especially on NCI.