### PR TITLE
Implement security recommendations from dlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,12 @@ repos:
       hooks:
           - id: flake8
             additional_dependencies:
+                  - dlint # Check common security issues
                   - flake8-broken-line # Don't escape newlines. (surround in parens or simplify)
                   - flake8-debugger # Don't commit debugger calls
                   - flake8-executable # Check shebangs and executable permissions
                   - flake8-logging-format # Use log arguments, not string format
+                  - flake8-pep3101 # Don't use old string % formatting
                   - flake8-pytest # Use plain assert, not unittest assertions
-                  - pep8-naming
+                  - pep8-naming # Follow pep8 naming rules (eg. function names lowercase)
 

--- a/eodatasets3/documents.py
+++ b/eodatasets3/documents.py
@@ -99,7 +99,7 @@ def new_metadata_path(dataset_path):
     if dataset_path.is_file():
         return dataset_path.parent.joinpath("{}.ga-md.yaml".format(dataset_path.name))
 
-    raise ValueError("Unhandled path type for %r" % dataset_path)
+    raise ValueError(f"Unhandled path type for {dataset_path!r}")
 
 
 def _find_any_metadata_suffix(path):

--- a/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
+++ b/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
@@ -3,7 +3,7 @@ import re
 import uuid
 from pathlib import Path
 from typing import Iterable, Dict
-from xml.etree import ElementTree
+from defusedxml import ElementTree
 
 import click
 import rasterio
@@ -20,7 +20,7 @@ def parse_xml(filepath: Path):
     Extracts metadata attributes from the xml document distributed
     alongside the MCD43A1 tiles.
     """
-    root = ElementTree.parse(str(filepath)).getroot()
+    root = ElementTree.parse(str(filepath), forbid_dtd=True).getroot()
 
     granule_id = root.find("*//ECSDataGranule/LocalGranuleID").text
     instrument = root.find("*//Platform/Instrument/InstrumentShortName").text

--- a/eodatasets3/prepare/sentinel_l1c_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1c_prepare.py
@@ -7,7 +7,7 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Tuple, Dict
-from xml.dom import minidom
+from defusedxml import minidom
 import click
 
 from eodatasets3 import DatasetAssembler
@@ -45,7 +45,7 @@ def process_product_info(product_path: Path) -> Dict:
         "sinergise_product_name": product["name"],
         "sinergise_product_id": product["id"],
         "datetime": tile["timestamp"],
-        "odc:region_code": "%s%s%s" % (utm_zone, latitude_band, grid_square),
+        "odc:region_code": f"{utm_zone}{latitude_band}{grid_square}",
         "sentinel:utm_zone": utm_zone,
         "sentinel:latitude_band": latitude_band,
         "sentinel:grid_square": grid_square,

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -28,7 +28,7 @@ from eodatasets3.properties import FileFormat
 
 
 def _format_representer(dumper, data: FileFormat):
-    return dumper.represent_scalar("tag:yaml.org,2002:str", "%s" % data.name)
+    return dumper.represent_scalar("tag:yaml.org,2002:str", f"{data.name}")
 
 
 def _uuid_representer(dumper, data):
@@ -37,7 +37,7 @@ def _uuid_representer(dumper, data):
     :type data: uuid.UUID
     :rtype: yaml.nodes.Node
     """
-    return dumper.represent_scalar("tag:yaml.org,2002:str", "%s" % data)
+    return dumper.represent_scalar("tag:yaml.org,2002:str", f"{data}")
 
 
 def represent_datetime(self, data: datetime):

--- a/eodatasets3/utils.py
+++ b/eodatasets3/utils.py
@@ -53,7 +53,7 @@ def read_paths_from_file(listing: Path) -> Iterable[Path]:
             path = Path(loc.strip())
             if not path.exists():
                 raise FileNotFoundError(
-                    "No such file or directory: %s" % (os.path.abspath(loc),)
+                    f"No such file or directory: {os.path.abspath(loc)}"
                 )
 
             yield path.absolute()

--- a/eodatasets3/verify.py
+++ b/eodatasets3/verify.py
@@ -13,7 +13,7 @@ from pathlib import Path
 _LOG = logging.getLogger(__name__)
 
 
-def find_exe(name):
+def find_exe(name: str):
     """
     Find the location of the given executable.
 
@@ -22,7 +22,7 @@ def find_exe(name):
     """
     executable = spawn.find_executable(name)
     if not executable:
-        raise Exception("No %s command found." % (name,))
+        raise Exception(f"No {name!r} command found.")
 
     return executable
 
@@ -77,7 +77,7 @@ def calculate_file_crc32(filename, block_size=1024 * 16):
                 break
             m = binascii.crc32(d, m)
 
-    return "%08x" % (m & 0xFFFFFFFF)
+    return f"{m & 0xFFFFFFFF:08x}"
 
 
 class PackageChecksum(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,13 @@ norecursedirs = .* build dist .git tmp*
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
+    # We're stuck with SHA1 for compatibily. Don't warn about it.
+    DUO130
 
 per-file-ignores =
     # Legacy code not worth converting
     tests/__init__.py: S001
+    tests/test_verify.py: PT009
 
 
 # Note that Black will enforce all code to line-length of 88.

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "cattrs",
         "ciso8601",
         "click",
+        "defusedxml",
         "jsonschema>=3",  # We want a Draft6Validator
         "numpy>=1.15.4",
         "pyproj",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,23 +150,6 @@ def temp_dir():
     return write_files({})
 
 
-def temp_file(suffix=""):
-    """
-    Get a temporary file path that will be cleaned up on exit.
-
-    Simpler than NamedTemporaryFile--- just a file path, no open mode or anything.
-    :return:
-    """
-    f = tempfile.mktemp(suffix=suffix)
-
-    def permissive_ignore(file_):
-        if os.path.exists(file_):
-            os.remove(file_)
-
-    atexit.register(permissive_ignore, f)
-    return f
-
-
 def file_of_size(path, size_mb):
     """
     Create a blank file of the given size.


### PR DESCRIPTION
Primarily: switch to a restricted XML parser, remove mktmp usage

... and add other relevant flake8 plugins used by the Explorer codebase.