### PR TITLE
Add validation for duplicate or missing measurement names and aliases

### DIFF
--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -108,7 +108,7 @@ def degrees_type(value):
     value = float(value)
 
     if not (-360.0 <= value <= 360.0):
-        raise ValueError("Expected percent between 0,100")
+        raise ValueError("Expected degrees between -360,+360")
 
     return value
 


### PR DESCRIPTION
We've seen both of these issues on recent product definitions, so it would be helpful for `eo3-validate` to check for them.

Example of use:

![Screenshot from 2021-04-16 10-45-20](https://user-images.githubusercontent.com/25688/114955898-fe19ed00-9ea0-11eb-95ce-ec5d7e386d97.png)

Or text:

```
❯ eo3-validate ard_s2.odc-product.yaml ga_s2am_ard_3-2-0_53JQJ_2020-10-31_final.odc-metadata.yaml
✗ ard_s2.odc-product
	E duplicate_measurement_name Name 'nbart_band07' is used more than once in a measurement name or alias.
 (Hint: Seen in nbart_red_edge_3)
✓ ga_s2am_ard_3-2-0_53JQJ_2020-10-31_final.odc-metadata
	W extra_measurements Dataset has measurements not present in product definition for 'ga_s2am_ard_3': nbar_nir_1, nbar_nir_2, nbar_red_edge_1, nbar_red_edge_2, nbar_red_edge_3, nbar_swir_3
 (Hint: This may be valid, as it's allowed by ODC. Set `expect_extra_measurements` to mute this.)

failure: 1 error, 1 warning
```

_Missing_ measurements from a product is only a warning, since it's valid in ODC, (and there's a flag to disable it)