### PR TITLE
Add ability to specify lineage directly as ids

### DIFF
--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -314,6 +315,13 @@ def test_s2_naming_conventions(tmp_path: Path):
         "sentinel:sentinel_tile_id"
     ] = "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
 
+    p.note_source_datasets(
+        "telemetry",
+        # Accepts multiple, and they can be strings or UUIDs:
+        "ca705033-0fc4-4f38-a47e-f425dfb4d0c7",
+        uuid.UUID("3781e90f-b677-40af-9439-b40f6e4dfadd"),
+    )
+
     # The property normaliser should have extracted inner fields
     assert p.properties["sentinel:datatake_start_datetime"] == datetime(
         2017, 8, 22, 1, 56, 26, tzinfo=timezone.utc
@@ -342,7 +350,6 @@ def test_s2_naming_conventions(tmp_path: Path):
             },
             "id": dataset_id,
             "label": "ga_s2am_blueberries_1-0-0_Oz_2018-11-04",
-            "lineage": {},
             "product": {
                 "href": "https://collections.dea.ga.gov.au/product/ga_s2am_blueberries_1",
                 "name": "ga_s2am_blueberries_1",
@@ -359,6 +366,12 @@ def test_s2_naming_conventions(tmp_path: Path):
                 "odc:region_code": "Oz",
                 "sentinel:datatake_start_datetime": datetime(2017, 8, 22, 1, 56, 26),
                 "sentinel:sentinel_tile_id": "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05",
+            },
+            "lineage": {
+                "telemetry": [
+                    "ca705033-0fc4-4f38-a47e-f425dfb4d0c7",
+                    "3781e90f-b677-40af-9439-b40f6e4dfadd",
+                ]
             },
         },
         generated_file=metadata_path,


### PR DESCRIPTION
The other lineage methods require a full source dataset metadata document or path to be given, which is not ideal for products with huge amounts of lineage.

Example usage:
```
p.note_source_datasets(
    # Classifier
    'level1',
    # Any number of ids
    'ca705033-0fc4-4f38-a47e-f425dfb4d0c7',
    '3781e90f-b677-40af-9439-b40f6e4dfadd',
)
```

(includes a test)

Requested by @bellemae 