### PR TITLE
Clean up warnings, deprecations, docs

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -195,7 +195,7 @@ class DatasetAssembler(EoFields):
         self._metadata_path = metadata_path
         self._allow_absolute_paths = allow_absolute_paths
 
-        self._accessories: Dict[str, Path] = {}
+        self._accessories: Dict[str, Location] = {}
         self._measurements = MeasurementRecord()
 
         self._user_metadata = dict()
@@ -996,7 +996,7 @@ class DatasetAssembler(EoFields):
 
         self._document_thumbnail(thumb_path, kind)
 
-    def add_accessory_file(self, name: str, path: Path):
+    def add_accessory_file(self, name: str, path: Location):
         """
         Record a reference to an additional file that's part of the dataset, but is
         not a band/measurement.

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -26,6 +26,14 @@ def _dea_uri(product_name, base_uri):
 
 @attr.s(auto_attribs=True, slots=True)
 class ProductDoc:
+    """
+    The product that this dataset belongs to.
+
+    "name" is the local name in ODC.
+
+    href is intended as a more global unique "identifier" uri for the product.
+    """
+
     name: str = None
     href: str = None
 
@@ -36,6 +44,8 @@ class ProductDoc:
 
 @attr.s(auto_attribs=True, slots=True, hash=True)
 class GridDoc:
+    """The grid describing a measurement/band's pixels"""
+
     shape: Tuple[int, int]
     transform: affine.Affine
 
@@ -57,6 +67,13 @@ class MeasurementDoc:
 
 @attr.s(auto_attribs=True, slots=True)
 class AccessoryDoc:
+    """
+    An accessory is an extra file included in the dataset that is not
+    a measurement/band.
+
+    For example: thumbnails, alternative metadata documents, or checksum files.
+    """
+
     path: str
     type: str = None
     name: str = attr.ib(metadata=dict(doc_exclude=True), default=None)

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -247,7 +247,7 @@ class ComplicatedNamingConventions:
         self._check_enough_properties_to_name()
         return self._dataset_label()
 
-    def destination_folder(self, base: Path):
+    def destination_folder(self, base: Path) -> Path:
         self._check_enough_properties_to_name()
         # DEA naming conventions folder hierarchy.
         # Example: "ga_ls8c_ard_3/092/084/2016/06/28"
@@ -467,7 +467,7 @@ class ComplicatedNamingConventionsDerivatives(ComplicatedNamingConventions):
         ]
         return "_".join(parts)
 
-    def destination_folder(self, base: Path):
+    def destination_folder(self, base: Path) -> Path:
         self._check_enough_properties_to_name()
         parts = [self.product_name, self.dataset.dataset_version.replace(".", "-")]
         parts.extend(utils.subfolderise(self.dataset.region_code))

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -14,7 +14,7 @@ import shapely
 import shapely.affinity
 import shapely.ops
 from affine import Affine
-from ruamel.yaml import YAML, ruamel, Representer
+from ruamel.yaml import YAML, Representer
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
@@ -113,12 +113,16 @@ def dumps_yaml(stream, *docs: Mapping) -> None:
 
 def load_yaml(p: Path) -> Dict:
     with p.open() as f:
-        return YAML(typ="safe").load(f)
+        return _yaml().load(f)
+
+
+def _yaml():
+    return YAML(typ="safe")
 
 
 def loads_yaml(stream: Union[Text, IO]) -> Iterable[Dict]:
     """Dump yaml through a stream, using the default deserialisation settings."""
-    return YAML(typ="safe").load_all(stream)
+    return _yaml().load_all(stream)
 
 
 def from_path(path: Path, skip_validation=False) -> DatasetDoc:
@@ -137,7 +141,7 @@ class InvalidDataset(Exception):
 
 def _get_schema_validator(p: Path) -> jsonschema.Draft6Validator:
     with p.open() as f:
-        schema = ruamel.yaml.safe_load(f)
+        schema = _yaml().load(f)
     klass = jsonschema.validators.validator_for(schema)
     klass.check_schema(schema)
     return klass(schema, types=dict(array=(list, tuple)))

--- a/tests/common.py
+++ b/tests/common.py
@@ -70,7 +70,7 @@ def assert_same_as_file(expected_doc: Dict, generated_file: Path, ignore_fields=
     assert generated_file.exists(), f"Expected file to exist {generated_file.name}"
 
     with generated_file.open("r") as f:
-        generated_doc = yaml.safe_load(f)
+        generated_doc = yaml.YAML(typ="safe").load(f)
 
     expected_doc = dict(expected_doc)
     for field in ignore_fields:

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -3,7 +3,7 @@ from functools import partial
 from pathlib import Path
 from pprint import pformat
 
-from ruamel import yaml
+from eodatasets3 import serialise
 from deepdiff import DeepDiff
 
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare
@@ -123,7 +123,9 @@ def test_prepare_ncep_reanalysis1_pr_wtr(tmpdir):
     )
 
     assert expected_metadata_path.exists()
-    docs = list(yaml.safe_load_all(expected_metadata_path.open()))
+
+    with expected_metadata_path.open("r") as f:
+        docs = list(serialise.loads_yaml(f))
 
     for idx in range(len(expected_doc)):
         doc_diff = _diff(

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -250,7 +250,7 @@ def test_dataset_no_measurements(tmp_path: Path):
         dataset_id, metadata_path = p.done()
 
     with metadata_path.open("r") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.YAML(typ="safe").load(f)
 
     assert doc["label"] == "chipmonk_sightings_2019", "Couldn't override label field"
 
@@ -268,7 +268,7 @@ def test_minimal_s1_dataset(tmp_path: Path):
         dataset_id, metadata_path = p.done()
 
     with metadata_path.open("r") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.YAML(typ="safe").load(f)
 
     assert doc["label"] == "s1ac_bck_2018-11-04", "Unexpected dataset label"
 
@@ -289,7 +289,7 @@ def test_minimal_s2_dataset_normal(tmp_path: Path):
         dataset_id, metadata_path = p.done()
 
     with metadata_path.open("r") as f:
-        doc = yaml.safe_load(f)
+        doc = yaml.YAML(typ="safe").load(f)
 
     metadata_path_offset = metadata_path.relative_to(tmp_path).as_posix()
     assert metadata_path_offset == (

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import gdal
+from osgeo import gdal
 import pytest
 import rasterio
 from click.testing import CliRunner


### PR DESCRIPTION
A lot of minor dependency warning clean-ups, type and doc improvements.

I've also loosened the "duplicate measurement" error on eo3 validate when the duplicate is within a single measurement. This is not harmful, and a lot of our old products make this mistake. So it's only a message now, not an error.
