### PR TITLE
Include constellation field in S2 data

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -65,6 +65,7 @@ class DatasetCompletenessWarning(UserWarning):
 class DatasetAssembler(EoFields):
     # Properties that can be inherited from a source dataset. (when auto_inherit_properties=True)
     INHERITABLE_PROPERTIES = {
+        "constellation",
         "datetime",
         "dtr:end_datetime",
         "dtr:start_datetime",
@@ -104,6 +105,7 @@ class DatasetAssembler(EoFields):
         "landsat:landsat_scene_id",
         "landsat:wrs_path",
         "landsat:wrs_row",
+        "mission",
         "odc:region_code",
         "sat:absolute_orbit",
         "sat:anx_datetime",

--- a/eodatasets3/prepare/sentinel_l1c_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1c_prepare.py
@@ -193,6 +193,7 @@ def prepare_and_write(
         p.dataset_id = _get_stable_id(p)
         p.properties["eo:platform"] = _get_platform_name(p.properties)
         p.properties["eo:instrument"] = "MSI"
+        p.properties["constellation"] = "sentinel-2"
         p.properties["odc:dataset_version"] = f"1.0.{p.processed:%Y%m%d}"
 
         p.properties["odc:file_format"] = "JPEG2000"

--- a/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
@@ -137,6 +137,7 @@ def expected_dataset_document():
         },
         "product": {"name": "esa_s2bm_level1_1"},
         "properties": {
+            "constellation": "sentinel-2",
             "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
             "eo:cloud_cover": 24.9912,
             "eo:gsd": 10,

--- a/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
@@ -104,6 +104,7 @@ def expected_dataset_document():
         },
         "product": {"name": "sinergise_s2bm_level1_1"},
         "properties": {
+            "constellation": "sentinel-2",
             "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
             "eo:cloud_cover": 24.9912,
             "eo:gsd": 10,


### PR DESCRIPTION
It and the Stac 'mission' field should be inheritable, too.