### PR TITLE
Allow for multi-platform products, custom product names

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -65,11 +65,11 @@ class DatasetCompletenessWarning(UserWarning):
 class DatasetAssembler(EoFields):
     # Properties that can be inherited from a source dataset. (when auto_inherit_properties=True)
     INHERITABLE_PROPERTIES = {
-        "constellation",
         "datetime",
         "dtr:end_datetime",
         "dtr:start_datetime",
         "eo:cloud_cover",
+        "eo:constellation",
         "eo:gsd",
         "eo:instrument",
         "eo:platform",

--- a/eodatasets3/prepare/sentinel_l1c_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1c_prepare.py
@@ -191,13 +191,15 @@ def prepare_and_write(
             )
 
         p.dataset_id = _get_stable_id(p)
-        p.properties["eo:platform"] = _get_platform_name(p.properties)
-        p.properties["eo:instrument"] = "MSI"
-        p.properties["constellation"] = "sentinel-2"
-        p.properties["odc:dataset_version"] = f"1.0.{p.processed:%Y%m%d}"
+
+        p.platform = _get_platform_name(p.properties)
+        p.instrument = "MSI"
+        p.constellation = "sentinel-2"
+
+        p.dataset_version = f"1.0.{p.processed:%Y%m%d}"
 
         p.properties["odc:file_format"] = "JPEG2000"
-        p.properties["odc:product_family"] = "level1"
+        p.product_family = "level1"
 
         for path in jp2_offsets:
             band_number = _extract_band_number(path.stem)

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -368,7 +368,7 @@ class StacPropertyView(collections.abc.MutableMapping):
                 f"Overriding property {key!r} " f"(from {self[key]!r} to {value!r})"
             )
             if allow_override:
-                warnings.warn(message)
+                warnings.warn(message, category=PropertyOverrideWarning)
             else:
                 raise KeyError(message)
 
@@ -376,6 +376,12 @@ class StacPropertyView(collections.abc.MutableMapping):
 
     def nested(self):
         return nest_properties(self._props)
+
+
+class PropertyOverrideWarning(UserWarning):
+    """A warning that a property was set twice with different values."""
+
+    ...
 
 
 class EoFields:

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -293,6 +293,7 @@ class StacPropertyView(collections.abc.MutableMapping):
         "odc:file_format": of_enum_type(FileFormat, strict=False),
         "odc:processing_datetime": datetime_type,
         "odc:producer": producer_check,
+        "odc:product": None,
         "odc:product_family": None,
         "odc:region_code": None,
         **_LANDSAT_EXTENDED_PROPS,
@@ -433,6 +434,17 @@ class EoFields:
     @instrument.setter
     def instrument(self, value: str):
         self.properties["eo:instrument"] = value
+
+    @property
+    def product_name(self) -> Optional[str]:
+        """
+        The ODC product
+        """
+        return self.properties.get("odc:product")
+
+    @product_name.setter
+    def product_name(self, value: str):
+        self.properties["odc:product"] = value
 
     @property
     def producer(self) -> str:

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -436,6 +436,17 @@ class EoFields:
         self.properties["eo:instrument"] = value
 
     @property
+    def constellation(self) -> str:
+        """
+        Constellation. Eg 'sentinel-2".
+        """
+        return self.properties.get("eo:constellation")
+
+    @constellation.setter
+    def constellation(self, value: str):
+        self.properties["eo:constellation"] = value
+
+    @property
     def product_name(self) -> Optional[str]:
         """
         The ODC product

--- a/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
@@ -137,12 +137,12 @@ def expected_dataset_document():
         },
         "product": {"name": "esa_s2bm_level1_1"},
         "properties": {
-            "constellation": "sentinel-2",
             "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
             "eo:cloud_cover": 24.9912,
             "eo:gsd": 10,
             "eo:instrument": "MSI",
             "eo:platform": "sentinel-2b",
+            "eo:constellation": "sentinel-2",
             "eo:sun_azimuth": 46.3307328858312,
             "eo:sun_elevation": 37.3713908882192,
             "odc:dataset_version": "1.0.20201011",

--- a/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
@@ -104,12 +104,12 @@ def expected_dataset_document():
         },
         "product": {"name": "sinergise_s2bm_level1_1"},
         "properties": {
-            "constellation": "sentinel-2",
             "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
             "eo:cloud_cover": 24.9912,
             "eo:gsd": 10,
             "eo:instrument": "MSI",
             "eo:platform": "sentinel-2b",
+            "eo:constellation": "sentinel-2",
             "eo:sun_azimuth": 46.3307328858312,
             "eo:sun_elevation": 37.3713908882192,
             "odc:dataset_version": "1.0.20201011",

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -199,6 +199,7 @@ def test_minimal_package_with_product_name(tmp_path: Path, l1_ls8_folder: Path):
     with DatasetAssembler(out) as p:
         p.datetime = datetime(2019, 7, 4, 13, 7, 5)
         p.product_name = "loch_ness_sightings"
+        p.processed = datetime(2019, 7, 4, 13, 8, 7)
 
         p.write_measurement("blue", blue_geotiff_path)
 

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -187,9 +187,48 @@ def test_dea_style_package(
     )
 
 
-def test_minimal_package(tmp_path: Path, l1_ls8_folder: Path):
+def test_minimal_package_with_product_name(tmp_path: Path, l1_ls8_folder: Path):
     """
-    What's the minimum number of fields we can set and still produce a package?
+    You can specify an ODC product name manually to avoid most of the name generation.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+
+    [blue_geotiff_path] = l1_ls8_folder.rglob("L*_B2.TIF")
+
+    with DatasetAssembler(out) as p:
+        p.datetime = datetime(2019, 7, 4, 13, 7, 5)
+        p.product_name = "loch_ness_sightings"
+
+        p.write_measurement("blue", blue_geotiff_path)
+
+        dataset_id, metadata_path = p.done()
+
+    assert dataset_id is not None
+    assert_file_structure(
+        out,
+        {
+            "loch_ness_sightings": {
+                "2019": {
+                    "07": {
+                        "04": {
+                            # Set a dataset version to get rid of 'beta' label.
+                            "loch_ness_sightings_2019-07-04.odc-metadata.yaml": "",
+                            "loch_ness_sightings_2019-07-04.proc-info.yaml": "",
+                            "loch_ness_sightings_2019-07-04_blue.tif": "",
+                            "loch_ness_sightings_2019-07-04.sha1": "",
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_minimal_generated_naming_package(tmp_path: Path, l1_ls8_folder: Path):
+    """
+    What's the minimum number of fields we can set and still generate file/product
+    names to produce a package?
     """
 
     out = tmp_path / "out"

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,6 +1,10 @@
+import warnings
+from contextlib import contextmanager
+
 import pytest
 
 from eodatasets3.model import DatasetDoc, ComplicatedNamingConventions
+from eodatasets3.properties import PropertyOverrideWarning
 
 
 def test_multi_platform_fields():
@@ -27,44 +31,54 @@ def test_multi_platform_fields():
     assert d.platform is None
 
 
+@contextmanager
+def ignore_property_overrides():
+    """Don't warn about setting a property twice."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", PropertyOverrideWarning)
+        yield
+
+
 def test_naming_abbreviations():
     d = DatasetDoc()
     names = ComplicatedNamingConventions(d)
 
-    assert names.platform_abbreviated is None
+    with ignore_property_overrides():
+        assert names.platform_abbreviated is None
 
-    # A single platform uses its known abbreviation.
-    d.platforms = ["landsat-5"]
-    assert names.platform_abbreviated == "ls5"
+        # A single platform uses its known abbreviation.
+        d.platforms = ["landsat-5"]
+        assert names.platform_abbreviated == "ls5"
 
-    # Multiple platforms from a known group use the group name.
-    d.platforms = ["landsat-5", "landsat_7"]
-    assert names.platform_abbreviated == "ls"
-    d.platforms = ["sentinel-2a", "sentinel-2b"]
-    assert names.platform_abbreviated == "s2"
+        # Multiple platforms from a known group use the group name.
+        d.platforms = ["landsat-5", "landsat_7"]
+        assert names.platform_abbreviated == "ls"
+        d.platforms = ["sentinel-2a", "sentinel-2b"]
+        assert names.platform_abbreviated == "s2"
 
-    # Non-groupable platforms are dash-separated.
-    d.platforms = ["landsat-5", "sentinel-2a"]
-    assert names.platform_abbreviated is None
+        # Non-groupable platforms are dash-separated.
+        d.platforms = ["landsat-5", "sentinel-2a"]
+        assert names.platform_abbreviated is None
 
 
 def test_unknown_abbreviations():
     d = DatasetDoc()
     names = ComplicatedNamingConventions(d)
 
-    # Unknown platforms are abbreviated by just removing dashes.
-    d.platform = "grover-1"
-    assert names.platform_abbreviated == "grover1"
+    with ignore_property_overrides():
+        # Unknown platforms are abbreviated by just removing dashes.
+        d.platform = "grover-1"
+        assert names.platform_abbreviated == "grover1"
 
-    # Constellation can be used as a fallback grouping.
-    d.platforms = ["clippings-1a", "clippings-2b"]
-    d.properties["constellation"] = "clippings"
-    assert names.platform_abbreviated == "clippings"
+        # Constellation can be used as a fallback grouping.
+        d.platforms = ["clippings-1a", "clippings-2b"]
+        d.properties["constellation"] = "clippings"
+        assert names.platform_abbreviated == "clippings"
 
-    # Unless unknown platforms aren't allowed
-    # (DEA wants to be stricter and add real abbreviations for everything.)
-    names = ComplicatedNamingConventions.for_standard_dea(d)
-    with pytest.raises(
-        ValueError, match="don't know the DEA abbreviation for platform"
-    ):
-        print(names.platform_abbreviated)
+        # Unless unknown platforms aren't allowed
+        # (DEA wants to be stricter and add real abbreviations for everything.)
+        names = ComplicatedNamingConventions.for_standard_dea(d)
+        with pytest.raises(
+            ValueError, match="don't know the DEA abbreviation for platform"
+        ):
+            print(names.platform_abbreviated)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,4 +1,6 @@
-from eodatasets3.model import DatasetDoc
+import pytest
+
+from eodatasets3.model import DatasetDoc, ComplicatedNamingConventions
 
 
 def test_multi_platform_fields():
@@ -23,3 +25,46 @@ def test_multi_platform_fields():
     d = DatasetDoc()
     d.platform = ""
     assert d.platform is None
+
+
+def test_naming_abbreviations():
+    d = DatasetDoc()
+    names = ComplicatedNamingConventions(d)
+
+    assert names.platform_abbreviated is None
+
+    # A single platform uses its known abbreviation.
+    d.platforms = ["landsat-5"]
+    assert names.platform_abbreviated == "ls5"
+
+    # Multiple platforms from a known group use the group name.
+    d.platforms = ["landsat-5", "landsat_7"]
+    assert names.platform_abbreviated == "ls"
+    d.platforms = ["sentinel-2a", "sentinel-2b"]
+    assert names.platform_abbreviated == "s2"
+
+    # Non-groupable platforms are dash-separated.
+    d.platforms = ["landsat-5", "sentinel-2a"]
+    assert names.platform_abbreviated is None
+
+
+def test_unknown_abbreviations():
+    d = DatasetDoc()
+    names = ComplicatedNamingConventions(d)
+
+    # Unknown platforms are abbreviated by just removing dashes.
+    d.platform = "grover-1"
+    assert names.platform_abbreviated == "grover1"
+
+    # Constellation can be used as a fallback grouping.
+    d.platforms = ["clippings-1a", "clippings-2b"]
+    d.properties["constellation"] = "clippings"
+    assert names.platform_abbreviated == "clippings"
+
+    # Unless unknown platforms aren't allowed
+    # (DEA wants to be stricter and add real abbreviations for everything.)
+    names = ComplicatedNamingConventions.for_standard_dea(d)
+    with pytest.raises(
+        ValueError, match="don't know the DEA abbreviation for platform"
+    ):
+        print(names.platform_abbreviated)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,25 @@
+from eodatasets3.model import DatasetDoc
+
+
+def test_multi_platform_fields():
+    """
+    Multiple platforms can be specified.
+
+    (they are normalised in eo3 as a sorted, comma-separated list)
+    """
+    d = DatasetDoc()
+    assert d.platform is None
+    assert d.platforms == set()
+
+    d.platforms = {"LANDSAT_5", "LANDSAT_4"}
+    assert d.platform == "landsat-4,landsat-5"
+    assert d.platforms == {"landsat-4", "landsat-5"}
+
+    d = DatasetDoc()
+    d.platform = "sentinel-2a, landsat_5, LANDSAT_5"
+    assert d.platform == "landsat-5,sentinel-2a"
+    assert d.platforms == {"landsat-5", "sentinel-2a"}
+
+    d = DatasetDoc()
+    d.platform = ""
+    assert d.platform is None


### PR DESCRIPTION
## 1. Multi-platform support

Allow multiple `platform`s to be stored as a list of comma-separated values.

(and add a `p.platforms` convenience property for accessing it as a sequence.)

```python
>>> # Set multiple platforms
>>> p.platform = 'landsat-5,landsat-7'
>>> # Or (identically):
>>> p.platforms == ["landsat5", "landsat7"]

>>> # Access them using either method:
>>> p.platforms
{"landsat5", "landsat7"}
>>> p.platform
'landsat-5,landsat-7'
```

They are normalised individually using our existing platform normalisation (lowercase etc), and maintained sorted automatically (so that comparison and matching between values is always stable).

- [x]  **TODO**: ~Decide on the finer details of how we handle multiple platforms in generated file names. I have made guesses here. We have examples that abbreviate multi-landsat as "ls", and one example in the standard that mention compound abbreviations like `ls5-s2` (which isn't valid in an ODC product name).~ For now, DEA naming conventiosn are strict (errors thrown when things are unknown)

## 2. Allow setting of the product name

Allow the user to set their own product name. Sometimes people don't want to deal with the automatic-generation complexities.

```python
    with DatasetAssembler(out) as p:
        p.datetime = datetime(2019, 7, 4, 13, 7, 5)
        p.product_name = "loch_ness_sightings"
        ...
```

## 3. One constellation field
Consistently use `eo:constellation` as the field name for constellations.

The previous PR #161  added `constellation`, not realising we already had `eo:constellation`. We haven't made a release yet so we can still change this without breaking things.


