### PR TITLE
Validate product definitions fully for ODC, & warn when no license is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,31 +77,43 @@ with the upcoming [Stac Item metadata](https://github.com/radiantearth/stac-spec
 ## Validator
 
 
-`eo3-validate` a lint-like checker to check eo3 metadata.
+`eo3-validate` a lint-like checker to check ODC documents.
+
+Give it ODC documents for your products, types and/or datasets to have
+them validated.
+
+    eo3-validate my-product.odc-product.yaml /tmp/path/to/dataset.odc-metadata.yaml
+
+You can also run with `--thorough` to have it open imagery files too, checking
+their properties match the product (nodata, dtype etc)
+
 
 	❯ eo3-validate --help
-	Usage: eo3-validate [OPTIONS] [PATHS]...
-
-	  Validate ODC dataset documents
-
-	  Paths can be both product and dataset documents, but each product must
-	  come before its datasets to be matched against it.
-
-	Options:
-	  --version                       Show the version and exit.
-	  -W, --warnings-as-errors        Fail if any warnings are produced
-	  --thorough                      Attempt to read the data/measurements, and
-					  check their properties match
-
-	  --expect-extra-measurements / --warn-extra-measurements
-					  Allow some dataset measurements to be
-					  missing from the product definition. This is
-					  (deliberately) allowed by ODC, but often a
-					  mistake. This flag disables the warning.
-
-	  -q, --quiet                     Only print problems, one per line
-	  --help                          Show this message and exit.
-
+    Usage: eo3-validate [OPTIONS] [PATHS]...
+    
+      Validate ODC dataset documents
+    
+      Paths can be products, dataset documents, or directories to scan (for
+      files matching names '*.odc-metadata.yaml' etc).
+    
+      But each product must be specified before its datasets to be validated
+      against them.
+    
+    Options:
+      --version                       Show the version and exit.
+      -W, --warnings-as-errors        Fail if any warnings are produced
+      --thorough                      Attempt to read the data/measurements, and
+                                      check their properties match
+    
+      --expect-extra-measurements / --warn-extra-measurements
+                                      Allow some dataset measurements to be
+                                      missing from the product definition. This is
+                                      (deliberately) allowed by ODC, but often a
+                                      mistake. This flag disables the warning.
+    
+      -q, --quiet                     Only print problems, one per line
+      --help                          Show this message and exit.
+ 
 
 
 ## Conversion to Stac metadata

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -179,6 +179,9 @@ DATASET_SCHEMA = _load_schema_validator(Path(__file__).parent / "dataset.schema.
 PRODUCT_SCHEMA = _load_schema_validator(
     DATACUBE_SCHEMAS_PATH / "dataset-type-schema.yaml"
 )
+METADATA_TYPE_SCHEMA = _load_schema_validator(
+    DATACUBE_SCHEMAS_PATH / "metadata-type-schema.yaml"
+)
 
 
 def from_doc(doc: Dict, skip_validation=False) -> DatasetDoc:

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -14,6 +14,8 @@ import shapely
 import shapely.affinity
 import shapely.ops
 from affine import Affine
+from datacube.model import SCHEMA_PATH as DATACUBE_SCHEMAS_PATH
+from datacube.utils import read_documents
 from ruamel.yaml import YAML, Representer
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from shapely.geometry import shape
@@ -145,19 +147,38 @@ def _is_json_array(checker, instance) -> bool:
     return isinstance(instance, (list, tuple))
 
 
-def _get_schema_validator(p: Path) -> jsonschema.Draft6Validator:
+def _load_schema_validator(p: Path) -> jsonschema.Draft6Validator:
+    """
+    Create a schema instance for the file.
+
+    (Assumes they are trustworthy. Only local schemas!)
+    """
     with p.open() as f:
         schema = _yaml().load(f)
     validator = jsonschema.validators.validator_for(schema)
     validator.check_schema(schema)
 
+    # Allow schemas to reference other schemas relatively
+    def doc_reference(path):
+        path = p.parent.joinpath(path)
+        if not path.exists():
+            raise ValueError(f"Reference not found: {path}")
+        referenced_schema = next(iter(read_documents(path)))[1]
+        return referenced_schema
+
+    ref_resolver = jsonschema.RefResolver.from_schema(
+        schema, handlers={"": doc_reference}
+    )
     custom_validator = jsonschema.validators.extend(
         validator, type_checker=validator.TYPE_CHECKER.redefine("array", _is_json_array)
     )
-    return custom_validator(schema)
+    return custom_validator(schema, resolver=ref_resolver)
 
 
-DATASET_SCHEMA = _get_schema_validator(Path(__file__).parent / "dataset.schema.yaml")
+DATASET_SCHEMA = _load_schema_validator(Path(__file__).parent / "dataset.schema.yaml")
+PRODUCT_SCHEMA = _load_schema_validator(
+    DATACUBE_SCHEMAS_PATH / "dataset-type-schema.yaml"
+)
 
 
 def from_doc(doc: Dict, skip_validation=False) -> DatasetDoc:

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -766,7 +766,7 @@ def run(
                 f"\t{message.level.name[0].upper()} {displayable_code} {message.reason}"
             )
             if message.hint:
-                echo(f' ({style("Hint", fg="green")}: {message.hint})')
+                echo(f'\t\t({style("Hint")}: {message.hint})')
 
     if not quiet:
         result = (

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -12,7 +12,7 @@ from eodatasets3 import DatasetAssembler
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
 from tests import assert_file_structure
-from tests.common import assert_same_as_file
+from tests.common import assert_same_as_file, assert_expected_eo3_doc
 
 
 def test_dea_style_package(
@@ -91,7 +91,7 @@ def test_dea_style_package(
 
     # TODO: check sha1 checksum list.
 
-    assert_same_as_file(
+    assert_expected_eo3_doc(
         {
             "$schema": "https://schemas.opendatacube.org/dataset",
             "id": dataset_id,
@@ -183,7 +183,7 @@ def test_dea_style_package(
             },
             "lineage": {"level1": ["a780754e-a884-58a7-9ac0-df518a67f59d"]},
         },
-        generated_file=metadata_path,
+        metadata_path,
     )
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -314,7 +314,9 @@ def test_missing_field(eo_validator: ValidateRunner, example_metadata: Dict):
 def test_invalid_ls8_schema(eo_validator: ValidateRunner, example_metadata: Dict):
     """When there's no eo3 $schema defined"""
     del example_metadata["$schema"]
-    eo_validator.assert_invalid(example_metadata, codes=("no_schema",))
+    eo_validator.assert_invalid(
+        example_metadata, codes=("no_schema",), suffix=".odc-metadata.yaml"
+    )
 
 
 def test_allow_optional_geo(eo_validator: ValidateRunner, example_metadata: Dict):


### PR DESCRIPTION
Expand `eo3-validate` for products.
- Add a warning for when no license is set (it's optional in ODC, but required in Stac. We should have licenses for everything.)
- Catch schema violations that will make the product fail to index into ODC.
- Improve product->dataset nodata comparison (when doing "thorough" checks of the tiff image).
- Add directory scanning. So you can just say `eo3-validate .` and it will validate ODC docs in the current directory.

There's quite a few test changes because the tests needed to be updated to use a real product definition, rather than a dummy one (which started failing validation).
