### PR TITLE
Fix allow-absolute, and tell people how to embed locations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,16 @@ nitpicky = True
 # Show warnings on page so people want to fix them more.
 keep_warnings = True
 
+doctest_global_setup = """
+import numpy
+import tempfile
+from uuid import UUID
+from datetime import datetime
+from affine import Affine
+from rasterio.crs import CRS
+from pathlib import Path
+"""
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -525,8 +525,7 @@ Now our dataset location is included in the document:
     product:
       name: quaternarius
 
-    locations:
-    - s3://dea-public-data-dev/wofs/quaternarius/2019/07/04/
+    location: s3://dea-public-data-dev/wofs/quaternarius/2019/07/04/
 
 When ODC sees a location in the metadata document like this, the inner paths
 will be relative to this location instead of where the metadata document is stored.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -475,17 +475,25 @@ to avoid automatic generation (or to avoid their finicky metadata requirements).
 
 See more examples in the assembler :attr:`.names <eodatasets3.DatasetPrepare.names>` property.
 
-I don't want to store metadata with my data
--------------------------------------------
+.. _data_hates_metadata:
 
-You may want your data to live in a different location to your metadata files,
-and possibly not store it at all.
+Separating metadata from data
+-----------------------------
 
-To do this, you can give your own metadata location that is different to the
-collection or dataset location.
+(Or. "I don’t want to store ODC metadata alongside my data!")
 
-Then, tell the Assembler to embed the dataset location in the metadata file
-with ``embed_location=True``
+You may want your data to live in a different location to your ODC metadata
+files, or even not store metadata on disk at all. But you still want it to be
+easily indexed.
+
+To do this, the ``done()`` commands include an ``embed_location=True`` argument.
+This will tell the Assemblers to embed the ``dataset_location`` into the
+output document.
+
+.. note ::
+
+   When indexing a dataset, if ODC finds an embedded location, it uses it in place of
+   the metadata document's own location.
 
 For example:
 
@@ -494,7 +502,8 @@ For example:
     metadata_path = tmp_path / "my-dataset.odc-metadata.yaml"
 
     with DatasetPrepare(
-        collection_location="s3://dea-public-data-dev/wofs",
+        # Our collection location is different to our metadata location!
+        collection_location="s3://dea-public-data-dev",
         metadata_path=metadata_path,
         allow_absolute_paths=True,
     ) as p:
@@ -525,16 +534,18 @@ Now our dataset location is included in the document:
     product:
       name: quaternarius
 
-    location: s3://dea-public-data-dev/wofs/quaternarius/2019/07/04/
+    location: s3://dea-public-data-dev/quaternarius/2019/07/04/
 
-When ODC sees a location in the metadata document like this, the inner paths
-will be relative to this location instead of where the metadata document is stored.
+Now ODC will ignore the actual location of the metadata file we are indexing, and
+use the embedded ``s3`` location instead.
 
 .. note ::
 
-   Note that we used absolute paths in this example for the measurement! (because it was easier to test)
+   Note that we added ``allow_absolute_paths=True`` for our own testing simplicity
+   in this guide.
 
-   Normally you might use an S3 url (or similar) for measurements too, as you're storing them in that location.
+   In reality, your measurements should live in that same ``s3://`` location,
+   and so they'll end up relative.
 
 Dataset Prepare class reference
 -------------------------------

--- a/eodatasets3/dataset.schema.yaml
+++ b/eodatasets3/dataset.schema.yaml
@@ -26,7 +26,8 @@ properties:
         format: url
     required:
       - name
-
+  location:
+    type: string
   locations:
     type: array
     items:

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -312,10 +312,10 @@ class LazyDatasetLocation:
                 "dataset_location or metadata_path!"
             )
 
-        offset = c.dataset_folder / c.metadata_file
+        offset = c.dataset_folder
         if offset.is_absolute():
             raise ValueError("Dataset offset is expected to be relative to collection")
-        return f"{c.collection_prefix}/{offset.as_posix()}"
+        return f"{c.collection_prefix}/{offset.as_posix()}/"
 
 
 class MissingRequiredFields(ValueError):
@@ -514,7 +514,9 @@ class NameGenerator:
        >>> collection = "s3://dea-public-data-dev/collections"
        >>> n = namer(conventions='default', properties=p, collection_prefix=collection)
        >>> n.dataset_location
-       's3://dea-public-data-dev/collections/ls7_nbar/2014/04/05/ls7_nbar_2014-04-05.odc-metadata.yaml'
+       's3://dea-public-data-dev/collections/ls7_nbar/2014/04/05/'
+       >>> n.metadata_file
+       PosixPath('ls7_nbar_2014-04-05.odc-metadata.yaml')
 
     All fields named ``*_file`` are filenames inside (relative to) the
     ``self.dataset_location``.

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -209,6 +209,9 @@ def from_doc(doc: Dict, skip_validation=False) -> DatasetDoc:
     # TODO: stable cattrs (<1.0) balks at the $schema variable.
     doc = doc.copy()
     del doc["$schema"]
+    location = doc.pop("location", None)
+    if location:
+        doc["locations"] = [location]
 
     c = cattr.Converter()
     c.register_structure_hook(uuid.UUID, _structure_as_uuid)
@@ -273,6 +276,10 @@ def to_doc(d: DatasetDoc) -> Dict:
         doc["geometry"] = shapely.geometry.mapping(d.geometry)
     doc["id"] = str(d.id)
     doc["properties"] = dict(d.properties)
+
+    if len(doc.get("locations", [])) == 1:
+        doc["location"] = doc.pop("locations")[0]
+
     return doc
 
 

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -344,6 +344,8 @@ _EO3_PROPERTY_ORDER = [
     "id",
     "label",
     "product",
+    "location",
+    "locations",
     "crs",
     "geometry",
     "grids",
@@ -351,8 +353,6 @@ _EO3_PROPERTY_ORDER = [
     "measurements",
     "accessories",
     "lineage",
-    "location",
-    "locations",
 ]
 
 

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -153,6 +153,7 @@ def validate_dataset(
     thorough: bool = False,
     readable_location: Union[str, Path] = None,
     expect_extra_measurements: bool = False,
+    expect_geometry: bool = True,
 ) -> ValidationMessages:
     """
     Validate a a dataset document, optionally against the given product.
@@ -203,7 +204,7 @@ def validate_dataset(
     if not dataset.product.href:
         _info("product_href", "A url (href) is recommended for products")
 
-    yield from _validate_geo(dataset)
+    yield from _validate_geo(dataset, expect_geometry=expect_geometry)
 
     # Note that a dataset may have no measurements (eg. telemetry data).
     # (TODO: a stricter mode for when we know we should have geo and measurement info)
@@ -693,9 +694,9 @@ def _is_nan(v):
     return isinstance(v, float) and math.isnan(v)
 
 
-def _validate_geo(dataset: DatasetDoc):
+def _validate_geo(dataset: DatasetDoc, expect_geometry: bool = True):
     has_some_geo = _has_some_geo(dataset)
-    if not has_some_geo:
+    if not has_some_geo and expect_geometry:
         yield _info("non_geo", "No geo information in dataset")
         return
 

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -388,26 +388,18 @@ def test_names_alone(tmp_path: Path):
         "ga_s2am_tester_1-2-3_023543_2013-02-03_sidecar.yaml"
     )
     assert convention.dataset_location == (
-        "s3://test-bucket/"
-        "ga_s2am_tester_1/023/543/2013/02/03/"
-        "ga_s2am_tester_1-2-3_023543_2013-02-03.odc-metadata.yaml"
+        "s3://test-bucket/" "ga_s2am_tester_1/023/543/2013/02/03/"
     )
 
     # Can we override generated names?
 
     convention.dataset_folder = Path("custom/dataset/offset/")
     # Now the generated metadata path will be inside it:
-    assert convention.dataset_location == (
-        "s3://test-bucket/"
-        "custom/dataset/offset/"
-        "ga_s2am_tester_1-2-3_023543_2013-02-03.odc-metadata.yaml"
-    )
+    assert convention.dataset_location == ("s3://test-bucket/" "custom/dataset/offset/")
 
     # Custom product name?
     convention.product_name = "my_custom_product"
-    assert convention.dataset_location == (
-        "s3://test-bucket/"
-        "custom/dataset/offset/"
+    assert convention.metadata_file == Path(
         "my_custom_product-2-3_023543_2013-02-03.odc-metadata.yaml"
     )
 
@@ -418,15 +410,13 @@ def test_local_path_naming(tmp_path: Path):
 
     convention = namer(p, conventions="dea", collection_prefix=Path("/my/collections"))
     assert convention.dataset_location == (
-        "file:///my/collections/"
-        "ga_s2am_tester_1/023/543/2013/02/03/"
-        "ga_s2am_tester_1-2-3_023543_2013-02-03.odc-metadata.yaml"
+        "file:///my/collections/" "ga_s2am_tester_1/023/543/2013/02/03/"
     )
+    assert convention.resolve_file(convention.metadata_file)
+
     # We can get it as a pathlib object
     assert convention.dataset_path == Path(
-        "/my/collections/"
-        "ga_s2am_tester_1/023/543/2013/02/03/"
-        "ga_s2am_tester_1-2-3_023543_2013-02-03.odc-metadata.yaml"
+        "/my/collections/" "ga_s2am_tester_1/023/543/2013/02/03"
     )
 
 

--- a/tests/integration/test_serialise.py
+++ b/tests/integration/test_serialise.py
@@ -6,13 +6,37 @@ from tests.common import dump_roundtrip
 
 
 def test_valid_document_works(tmp_path: Path, example_metadata: Dict):
-    generated_doc = dump_roundtrip(example_metadata)
+    assert_unchanged_after_roundstrip(example_metadata)
 
+
+def assert_unchanged_after_roundstrip(doc: Dict):
+    generated_doc = dump_roundtrip(doc)
     # Do a serialisation roundtrip and check that it's still identical.
     reserialised_doc = dump_roundtrip(
         serialise.to_doc(serialise.from_doc(generated_doc))
     )
-
     assert generated_doc == reserialised_doc
-
     assert serialise.from_doc(generated_doc) == serialise.from_doc(reserialised_doc)
+
+
+def test_location_serialisation(tmp_path: Path, l1_ls8_folder_md_expected: Dict):
+
+    l1_ls8_folder_md_expected["location"] = "s3://test/url/metadata.txt"
+    assert_unchanged_after_roundstrip(l1_ls8_folder_md_expected)
+
+
+def test_location_single_serialisation(tmp_path: Path, l1_ls8_folder_md_expected: Dict):
+
+    # Always serialises a single location as 'location'
+    location = "https://some/test/path"
+
+    # Given multiple
+    l1_ls8_folder_md_expected["locations"] = [location]
+
+    reserialised_doc = dump_roundtrip(
+        serialise.to_doc(serialise.from_doc(l1_ls8_folder_md_expected))
+    )
+
+    # We get singular
+    assert reserialised_doc["location"] == location
+    assert "locations" not in reserialised_doc


### PR DESCRIPTION
People often ask on Slack how to write a metadata document that doesn't sit in the same location as their data.

This [adds a section to the documentation with an example of doing this](https://jez-eod3.readthedocs.io/en/latest/#separating-metadata-from-data).

Also includes related changes:

- fixes `allow_absolute_paths=True`, which evidentially didn't have a test in our repository (none of our products used absolute paths...). The doctest now exercises it.
- Changes the default `dataset_location` to be a folder with ending slash, instead of a metadata file, since this will work with more use cases:

       From: 's3://dea-public-data-dev/collections/ls7_nbar/2014/04/05/ls7_nbar_2014-04-05.odc-metadata.yaml'
         To: 's3://dea-public-data-dev/collections/ls7_nbar/2014/04/05/'
The dataset location was never previously output, so we can change this without breaking backwards compat.
- Closes #91 

