### PR TITLE
Fix codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CodeCovToken }}
-          file: ./tests/coverage.xml
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pip-log.txt
 nosetests.xml
 .hypothesis
 .cache
+coverage.xml
 
 # PyCharm / IntelliJ
 *.iml

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,7 +8,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Run tests, taking coverage.
 # Users can specify extra folders as arguments.
-pytest --cov eodatasets3 --durations=5 "${script_dir}" $@
+pytest --cov eodatasets3 --cov-report=xml --durations=5 "${script_dir}" $@
 
 # Run sphinx inline tests
 #


### PR DESCRIPTION
Codecov expects a full coverage.xml. The normal .coverage
file output by pytest-cov is insufficient.

This can either be generated with these extra args to pytest-cov,
or by using the standalone `coverage` tool, which we could do only
in CI, but I'm not sure it's available in GHA by default, and we're
running most things in docker anyway. It's messy, these seems reasonable.