### PR TITLE
Add sensible default metadata paths

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -590,23 +590,23 @@ But you usually don't need to give them explicitly. They will be inferred if mis
  #. If you only give a dataset location, a metadata path will be created as a
     sibling file with ``.odc-metadata.yaml`` suffix within the same "directory" as the location.::
 
-        dataset_location =       "file:///tmp/`ls7_nbar_20120403_c1/my-dataset.tar"
+        dataset_location       = "file:///tmp/ls7_nbar_20120403_c1/my-dataset.tar"
         inferred_metadata_path = "file:///tmp/ls7_nbar_20120403_c1/my-dataset.odc-metadata.yaml"
 
- #. ... or specify neither! And have them generated from a base `collection_path`.::
+ #. ... or you can give neither of them! And they will be generated from a base `collection_path`.::
 
-        collection_path = "file:///collections"
+        collection_path           = "file:///collections"
         inferred_dataset_location = "file:///collections/ga_s2am_level4_3/023/543/2013/02/03/
-        inferred_metadata_path = "file:///collections/ga_s2am_level4_3/023/543/2013/02/03/ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml
+        inferred_metadata_path    = "file:///collections/ga_s2am_level4_3/023/543/2013/02/03/ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml
 
 
 .. note::
-   All locations can be given as a :class:`pathlib.Path`, and they will
-   be converted into URLs for you.
+   For local files, you can give the location as a :class:`pathlib.Path`,
+   and it will internally be converted into a URL for you.
 
-
-These offsets from a collection path are generated from your metadata properties and
-chosen naming conventions. You can also :attr:`override parts of it individually <eodatasets3.DatasetPrepare.names>`.
+In the third case, the folder and file names are generated from your
+metadata properties and chosen naming convention. You can
+also :attr:`set folders, files and parts yourself <eodatasets3.DatasetPrepare.names>`.
 
 Specifying a collection path::
 
@@ -617,8 +617,10 @@ Let's print out a table of example default paths for each built-in naming conven
 
 .. testcode ::
 
-   from eodatasets3 import namer, names, DatasetDoc
+   from eodatasets3 import namer, DatasetDoc
+   import eodatasets3.names
 
+   # Build an example dataset
    p = DatasetDoc()
    p.platform = "sentinel-2a"
    p.instrument = "MSI"
@@ -632,32 +634,34 @@ Let's print out a table of example default paths for each built-in naming conven
    p.collection_number = 3
    p.properties['sentinel:sentinel_tile_id'] = 'S2B_OPER_MSI_L1C_TL_VGS4_20210426T010904_A021606_T56JMQ_N03.00'
 
-   collection_prefix = 'https://collections.test'
+   collection_prefix = 'https://test-collection'
 
    # Print the result for each known convention
    header = f"{'convention':20} {'metadata_file':64} dataset_location"
    print(header)
    print('-' * len(header))
-   for convention in names.KNOWN_CONVENTIONS.keys():
-       n = namer(p, conventions=convention, collection_prefix=collection_prefix)
-       print(f"{convention:20} {str(n.metadata_file):64} {n.dataset_location}")
+   for conventions in eodatasets3.names.KNOWN_CONVENTIONS.keys():
+       n = namer(p, conventions=conventions, collection_prefix=collection_prefix)
+       print(f"{conventions:20} {str(n.metadata_file):64} {n.dataset_location}")
+
+Result:
 
 .. testoutput ::
 
    convention           metadata_file                                                    dataset_location
    ------------------------------------------------------------------------------------------------------
-   default              ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://collections.test/ga_s2am_level4_3/023/543/2013/02/03/
-   dea                  ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://collections.test/ga_s2am_level4_3/023/543/2013/02/03/
-   dea_s2               ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://collections.test/ga_s2am_level4_3/023/543/2013/02/03/20210426T010904/
-   dea_s2_derivative    ga_s2_level4_3_023543_2013-02-03_final.odc-metadata.yaml         https://collections.test/ga_s2_level4_3/1-2-3/023/543/2013/02/03/20210426T010904/
-   dea_c3               ga_s2_level4_3_023543_2013-02-03_final.odc-metadata.yaml         https://collections.test/ga_s2_level4_3/1-2-3/023/543/2013/02/03/
-   deafrica             level4_s2_023543_2013-02-03_final.odc-metadata.yaml              https://collections.test/level4_s2/1-2-3/023/543/2013/02/03/
+   default              ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://test-collection/ga_s2am_level4_3/023/543/2013/02/03/
+   dea                  ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://test-collection/ga_s2am_level4_3/023/543/2013/02/03/
+   dea_s2               ga_s2am_level4_3-2-3_023543_2013-02-03_final.odc-metadata.yaml   https://test-collection/ga_s2am_level4_3/023/543/2013/02/03/20210426T010904/
+   dea_s2_derivative    ga_s2_level4_3_023543_2013-02-03_final.odc-metadata.yaml         https://test-collection/ga_s2_level4_3/1-2-3/023/543/2013/02/03/20210426T010904/
+   dea_c3               ga_s2_level4_3_023543_2013-02-03_final.odc-metadata.yaml         https://test-collection/ga_s2_level4_3/1-2-3/023/543/2013/02/03/
+   deafrica             level4_s2_023543_2013-02-03_final.odc-metadata.yaml              https://test-collection/level4_s2/1-2-3/023/543/2013/02/03/
 
 
 .. note::
 
    The ``default`` conventions look the same as ``dea`` here, but ``dea`` is
-   stricter in its mandatory metadata fields (to follow policies within the
+   stricter in its mandatory metadata fields (following policies within the
    organisation).
 
    You can leave out many more properties from your metadata in ``default`` and they

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -605,12 +605,12 @@ class NameGenerator:
     #: (Defaults to the metadata path inside the dataset_folder)
     dataset_location: str = LazyDatasetLocation()
 
-    #: The path to the ODC metadata file.
+    #: The path or URL to the ODC metadata file.
     #:
-    #: (it's relative to self.dataset_location ... but could be absolute too)
+    #: (if relative, it's relative to self.dataset_location ... but could be absolute too)
     #:
     #: Example: ``Path('ga_ls8c_ones_3-0-0_090084_2016-01-21_final.odc-metadata.yaml')``
-    metadata_file: Path = LazyFileName("", "odc-metadata.yaml")
+    metadata_file: Union[str, Path] = LazyFileName("", "odc-metadata.yaml")
 
     #: The name of a checksum file
     checksum_file: Path = LazyFileName("", "sha1")

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -129,6 +129,16 @@ def degrees_type(value):
     return value
 
 
+def identifier_type(v: str):
+    v = v.replace("-", "_")
+    if not v.isidentifier() or not v.islower():
+        warnings.warn(
+            f"{v!r} is expected to be an identifier "
+            "(alphanumeric with underscores, typically lowercase)"
+        )
+    return v
+
+
 def producer_check(value):
     if "." not in value:
         warnings.warn(
@@ -304,7 +314,7 @@ class Eo3Dict(collections.abc.MutableMapping):
         "odc:processing_datetime": datetime_type,
         "odc:producer": producer_check,
         "odc:product": None,
-        "odc:product_family": None,
+        "odc:product_family": identifier_type,
         "odc:region_code": None,
         **_LANDSAT_EXTENDED_PROPS,
         **_GQA_FMASK_PROPS,

--- a/tests/common.py
+++ b/tests/common.py
@@ -47,15 +47,17 @@ def assert_expected_eo3_path(
         # We check the geometry below
         ignore_fields=("geometry",) + tuple(ignore_fields),
     )
-    # Compare geometry after parsing, rather than comparing the raw dict values.
-    produced_dataset = serialise.from_path(expected_path)
-    expected_dataset = serialise.from_doc(expected_doc, skip_validation=True)
-    if expected_dataset.geometry is None:
-        assert produced_dataset.geometry is None
-    else:
-        assert_shapes_mostly_equal(
-            produced_dataset.geometry, expected_dataset.geometry, 0.00000001
-        )
+
+    if "geometry" not in ignore_fields:
+        # Compare geometry after parsing, rather than comparing the raw dict values.
+        produced_dataset = serialise.from_path(expected_path)
+        expected_dataset = serialise.from_doc(expected_doc, skip_validation=True)
+        if expected_dataset.geometry is None:
+            assert produced_dataset.geometry is None
+        else:
+            assert_shapes_mostly_equal(
+                produced_dataset.geometry, expected_dataset.geometry, 0.00000001
+            )
 
 
 def assert_shapes_mostly_equal(


### PR DESCRIPTION
This is a refinement of the changes in #171 and #173

In these changes, you can now specify a `dataset_location` without a giving a collection or metadata path.

This PR adds more useful default metadata_path names using the `*.odc-metadata.yaml` suffix convention.

- Added a section to the docs called "Understanding Locations": https://jez-eod3.readthedocs.io/en/latest/#understanding-locations (with embedded doc tests for code)
- Added tar file location test: https://github.com/GeoscienceAustralia/eo-datasets/pull/175/files#diff-25a91f608ef75ef5408a22267ea1c77c83b8237373abe34eba13544c1508962eR372