### PR TITLE
Expand `eo3-validate`: product matching, geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,7 @@ metadata doc for Open Data Cube, and create appropriate file and folder structur
 
 If you already have existing imagery, you can use DatasetAssembler to create a matching metadata document. 
 
-Many other uses and fields are available, see [the docs](https://eodatasets.readthedocs.io/en/latest/). 
-
-Further examples can be seen in the tests [tests/integration/test_assemble.py](tests/integration/test_assemble.py),
-[L1](eodatasets3/prepare/landsat_l1_prepare.py) or [ARD](eodatasets3/wagl.py) packagers.
+See [the documentation guide for more features and examples](https://eodatasets.readthedocs.io/en/latest/).
 
 ## Open Data Cube compatibility
 
@@ -71,6 +68,8 @@ Datacube versions from 1.8 onwards are compatible natively with eo3.
 
 eo3 adds information about the native grid of the data, and aims to be more easily interoperable 
 with the upcoming [Stac Item metadata](https://github.com/radiantearth/stac-spec/tree/master/item-spec).
+
+# Other Tools Included
 
 ## Validator
 
@@ -114,7 +113,7 @@ their properties match the product (nodata, dtype etc)
  
 
 
-## Conversion to Stac metadata
+## Stac metadata conversion
 
 `eo3-to-stac`: Convert an EO3 metadata doc to a Stac Item
 
@@ -140,47 +139,15 @@ Example usage:
 	LT05_L1TP_113081_19880330_20170209_01_T1.odc-metadata.yaml
 	LT05_L1TP_113081_19880330_20170209_01_T1.stac-item.json
 
+## Prep Scripts 
 
-# Development
-
-
-Run the tests using [pytest](http://pytest.org/).
-
-	❯ pytest
-
-You may need to install test dependencies first:
-
-	❯ pip install -e .[test]
-
-Dependencies such as gdal can be tricky to install on some systems. You
-may prefer to use the included Docker file for development: run `make
-build` to create a container, and `make test` to run tests.
-
-We have strict linting and formatting checks on this reposistory, so
-please run pre-commit (below) after checkout.
-
-## Pre-commit setup
-
-	❯ pip install pre-commit
-	❯ pre-commit install
-
-(if you are using Conda, you need to `conda install pre_commit` instead of using pip)
-
-Your code will now be formatted and validated before each commit. You can also invoke it manually by running `pre-commit run`
-
-This allows you to immediately catch and fix issues before you raise a pull request that fails.
-
-Most notably, all code is formatted using
-[black](https://github.com/ambv/black), and checked with
-[pyflakes](https://github.com/PyCQA/pyflakes).
-
-# DEA Prep
-
-Some included scripts to prepare existing DEA products.
+Some scripts are included for preparing common metadata documents, 
+such as landsat scenes.
 
 `eo3-prepare`: Prepare ODC metadata from the commandline.
 
-Some preparers need the ancillary dependencies: `pip install .[ancillary]`
+Some sub-commands need the ancillary dependencies, for reading from
+exotic formats: `pip install .[ancillary]`
 
 	❯ eo3-prepare --help
 	Usage: eo3-prepare [OPTIONS] COMMAND [ARGS]...
@@ -231,6 +198,38 @@ Some preparers need the ancillary dependencies: `pip install .[ancillary]`
 
 	  --help                          Show this message and exit.
 
+
+# Development Setup
+
+Run the tests using [pytest](http://pytest.org/).
+
+	❯ pytest
+
+You may need to install test dependencies first:
+
+	❯ pip install -e .[test]
+
+Dependencies such as gdal can be tricky to install on some systems. You
+may prefer to use the included Docker file for development: run `make
+build` to create a container, and `make test` to run tests.
+
+We have strict linting and formatting checks on this reposistory, so
+please run pre-commit (below) after checkout.
+
+## Pre-commit setup
+
+	❯ pip install pre-commit
+	❯ pre-commit install
+
+(if you are using Conda, you need to `conda install pre_commit` instead of using pip)
+
+Your code will now be formatted and validated before each commit. You can also invoke it manually by running `pre-commit run`
+
+This allows you to immediately catch and fix issues before you raise a pull request that fails.
+
+Most notably, all code is formatted using
+[black](https://github.com/ambv/black), and checked with
+[pyflakes](https://github.com/PyCQA/pyflakes).
 
 
 ## Creating Releases

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -230,10 +230,10 @@ class DatasetPrepare(Eo3Interface):
         There are three optional paths that can be specified. At least one must be specified. Collection,
         dataset or metadata path.
 
-        - A *collection path* is the root folder where datasets will live (in sub-[sub]-folders).
-        - Each dataset has its own *dataset location*, as stored in an Open Data Cube index.
-          All paths inside the metadata document are relative to this location.
-        - An output *metadata document location*.
+         - A ``collection_path`` is the root folder where datasets will live (in sub-[sub]-folders).
+         - Each dataset has its own ``dataset_location``, as stored in an Open Data Cube index.
+           All paths inside the metadata document are relative to this location.
+         - An output ``metadata_path`` document location*.
 
         If you're writing data, you typically only need to specify the collection path, and the others
         will be automatically generated using the naming conventions.
@@ -1038,10 +1038,10 @@ class DatasetAssembler(DatasetPrepare):
         There are three optional paths that can be specified. At least one must be specified. Collection,
         dataset or metadata path.
 
-        - A *collection path* is the root folder where datasets will live (in sub-[sub]-folders).
-        - Each dataset has its own *dataset location*, as stored in an Open Data Cube index.
-          All paths inside the metadata document are relative to this location.
-        - An output *metadata document location*.
+         - A ``collection_path`` is the root folder where datasets will live (in sub-[sub]-folders).
+         - Each dataset has its own ``dataset_location``, as stored in an Open Data Cube index.
+           All paths inside the metadata document are relative to this location.
+         - An output ``metadata_path`` document location*.
 
         If you're writing data, you typically only need to specify the collection path, and the others
         will be automatically generated using the naming conventions.

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -701,7 +701,8 @@ def _validate_geo(dataset: DatasetDoc, expect_geometry: bool = True):
         return
 
     if dataset.geometry is None:
-        yield _error("incomplete_geo", "Dataset has some geo fields but no geometry")
+        if expect_geometry:
+            yield _info("incomplete_geo", "Dataset has some geo fields but no geometry")
     elif not dataset.geometry.is_valid:
         yield _error(
             "invalid_geometry",

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -679,9 +679,9 @@ def _match_product(
 
         difference_hint = _differences_as_hint(closest_differences)
         return None, [
-            _warning(
+            _error(
                 "unknown_product",
-                "Cannot match dataset to product",
+                "Dataset does not match the given products",
                 hint=f"Closest match is {closest_product_name}, with differences:"
                 f"\n{difference_hint}",
             )

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -11,7 +11,7 @@ import re
 import sys
 from datetime import timedelta, datetime
 from pathlib import Path
-from typing import List, Sequence, Optional, Iterable, Any, Tuple, Dict, Mapping
+from typing import List, Sequence, Optional, Iterable, Any, Tuple, Dict
 from uuid import UUID
 
 import attr
@@ -30,7 +30,7 @@ from eodatasets3.model import DatasetDoc
 from eodatasets3.properties import Eo3Interface
 from eodatasets3.serialise import loads_yaml
 from eodatasets3.ui import bool_style
-from eodatasets3.utils import default_utc
+from eodatasets3.utils import default_utc, flatten_dict
 
 try:
     import h5py
@@ -684,27 +684,12 @@ def package(
                 return p.done()
 
 
-def _flatten_dict(d: Mapping, prefix=None, separator=".") -> Iterable[Tuple[str, Any]]:
-    """
-    >>> dict(_flatten_dict({'a' : 1, 'b' : {'inner' : 2},'c' : 3}))
-    {'a': 1, 'b.inner': 2, 'c': 3}
-    >>> dict(_flatten_dict({'a' : 1, 'b' : {'inner' : {'core' : 2}}}, prefix='outside', separator=':'))
-    {'outside:a': 1, 'outside:b:inner:core': 2}
-    """
-    for k, v in d.items():
-        name = f"{prefix}{separator}{k}" if prefix else k
-        if isinstance(v, Mapping):
-            yield from _flatten_dict(v, prefix=name, separator=separator)
-        else:
-            yield name, v
-
-
 def _read_gqa_doc(p: DatasetAssembler, doc: Dict):
     _take_software_versions(p, doc)
     p.extend_user_metadata("gqa", doc)
 
     # TODO: more of the GQA fields?
-    for k, v in _flatten_dict(doc["residual"], separator="_"):
+    for k, v in flatten_dict(doc["residual"], separator="_"):
         p.properties[f"gqa:{k}"] = v
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -691,7 +691,7 @@ def test_complains_about_product_not_matching(
     eo_validator.assert_invalid(product, l1_ls8_metadata_path)
     assert (
         eo_validator.messages.get("unknown_product")
-        == "Cannot match dataset to product"
+        == "Dataset does not match the given products"
     )
 
 

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -676,6 +676,25 @@ def test_complains_about_measurement_lists(
     )
 
 
+def test_complains_about_product_not_matching(
+    eo_validator: ValidateRunner,
+    l1_ls8_metadata_path: Path,
+    product: Dict,
+):
+    """
+    Complains when we're given products but they don't match the dataset
+    """
+
+    # A metadata field that's not in the dataset.
+    product["metadata"]["favourite_sandwich"] = "cucumber"
+
+    eo_validator.assert_invalid(product, l1_ls8_metadata_path)
+    assert (
+        eo_validator.messages.get("unknown_product")
+        == "Cannot match dataset to product"
+    )
+
+
 def test_complains_about_impossible_nodata_vals(
     eo_validator: ValidateRunner,
     l1_ls8_metadata_path: Path,


### PR DESCRIPTION
As suggested by Lan-Wei: it would be nice if the validator checked that a dataset matches a given product (according to ODC's match rules). Mismatched products are very common issues on Slack from users.

The validator will now try to match the product, and if no match, prints out which fields are different:
```
I strange_product_claim Dataset claims to be product 'usgs_ls8c_level1_2', but doesn't match its fields
	Hint: properties.eo:platform: 'landsat-8' != 'LANDSAT_8'
	      properties.eo:instrument: 'OLI_TIRS' != 'OLI_TIRSS'
	      properties.landsat:collection_number: 2 != 3
```

- Make the valid_data geometry field optional, to match upstream ODC.
- Tweaks to readme structure.