### PR TITLE
Consistently use str (url), not paths, in naming API

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -211,8 +211,8 @@ class DatasetPrepare(Eo3Interface):
         self,
         collection_location: Optional[Location] = None,
         *,
-        dataset_location: Optional[Union[str, Path]] = None,
-        metadata_path: Optional[Path] = None,
+        dataset_location: Optional[Location] = None,
+        metadata_path: Optional[Location] = None,
         dataset_id: Optional[uuid.UUID] = None,
         allow_absolute_paths: bool = False,
         naming_conventions: Optional[str] = None,
@@ -356,7 +356,7 @@ class DatasetPrepare(Eo3Interface):
         #: Change the folder offset for each dataset. All generated files paths are relative
         #: to this folder (and it is relative to the collection path)::
         #:
-        #:     p.names.dataset_folder = Path("datasets/january/2021")
+        #:     p.names.dataset_folder = "datasets/january/2021"
         #:
         #: Set a different pattern used for generating filenames
         #: All filenames have a file_id (eg. "odc-metadata" or "") and a suffix (eg. "yaml")
@@ -366,7 +366,7 @@ class DatasetPrepare(Eo3Interface):
         #:
         #: The path to the EO3 metadata doc (relative path to the dataset location)::
         #:
-        #:     p.names.metadata_file = Path("my-metadata.odc-metadata.yaml")
+        #:     p.names.metadata_file = "my-metadata.odc-metadata.yaml"
         #:
         #: The URI for the product::
         #:
@@ -401,7 +401,7 @@ class DatasetPrepare(Eo3Interface):
             and has_metadata_path
             and (not has_collection_location)
         ):
-            self.names.dataset_location = self.names.metadata_file
+            self.names.dataset_location = resolve_location(self.names.metadata_file)
 
         # If they only gave a dataset location, and don't have naming conventions, make metadata file a sibling.
         if (not has_metadata_path) and no_naming_specified and has_dataset_location:
@@ -1637,7 +1637,7 @@ class DatasetAssembler(DatasetPrepare):
 
             if self._exists_behaviour == IfExists.Skip:
                 # Something else created it while we were busy.
-                warnings.warn(f"Skipping -- exists: {self.names.dataset_folder}")
+                warnings.warn(f"Skipping -- exists: {dataset_folder}")
             elif self._exists_behaviour == IfExists.ThrowError:
                 raise
             elif self._exists_behaviour == IfExists.Overwrite:

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -245,12 +245,14 @@ def test_in_memory_dataset(tmp_path: Path, l1_ls8_folder: Path):
 
     [blue_geotiff_path] = l1_ls8_folder.rglob("L*_B2.TIF")
 
-    p = DatasetPrepare(dataset_location=out / "dataset.txt")
+    dataset_location = out / "my/custom/dataset/path/ls_whatever.stac-item.json"
+
+    p = DatasetPrepare(dataset_location=dataset_location)
     p.datetime = datetime(2019, 7, 4, 13, 7, 5)
     p.product_name = "loch_ness_sightings"
     p.processed = datetime(2019, 7, 4, 13, 8, 7)
 
-    pretend_path = out / "our_image_dont_read_it.tif"
+    pretend_path = dataset_location.parent / "our_image_dont_read_it.tif"
     p.note_measurement(
         "blue",
         pretend_path,
@@ -271,12 +273,15 @@ def test_in_memory_dataset(tmp_path: Path, l1_ls8_folder: Path):
     del doc["id"]
 
     # Users can ask the generator for file names:
-    assert p.names.measurement_filename("red") == Path(
-        "loch_ness_sightings_2019-07-04_red.tif"
+    assert (
+        p.names.measurement_filename("red") == "loch_ness_sightings_2019-07-04_red.tif"
     )
 
-    assert p.names.dataset_folder / p.names.measurement_filename("red") == Path(
-        "loch_ness_sightings/2019/07/04/loch_ness_sightings_2019-07-04_red.tif"
+    # The computed file paths are relative to our given dataset location.
+    out_url = out.as_uri()
+    assert (
+        p.names.resolve_file(p.names.measurement_filename("red"))
+        == f"{out_url}/my/custom/dataset/path/loch_ness_sightings_2019-07-04_red.tif"
     )
 
     pprint(doc)

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -383,24 +383,27 @@ def test_names_alone(tmp_path: Path):
     convention = namer(p, conventions="dea", collection_prefix="s3://test-bucket")
 
     assert convention.product_name == "ga_s2am_tester_1"
-    assert convention.dataset_folder == Path("ga_s2am_tester_1/023/543/2013/02/03")
-    assert convention.metadata_filename(kind="sidecar") == Path(
-        "ga_s2am_tester_1-2-3_023543_2013-02-03_sidecar.yaml"
+    assert convention.dataset_folder == "ga_s2am_tester_1/023/543/2013/02/03"
+    assert (
+        convention.metadata_filename(kind="sidecar")
+        == "ga_s2am_tester_1-2-3_023543_2013-02-03_sidecar.yaml"
     )
+
     assert convention.dataset_location == (
-        "s3://test-bucket/" "ga_s2am_tester_1/023/543/2013/02/03/"
+        "s3://test-bucket/ga_s2am_tester_1/023/543/2013/02/03/"
     )
 
     # Can we override generated names?
 
     convention.dataset_folder = Path("custom/dataset/offset/")
     # Now the generated metadata path will be inside it:
-    assert convention.dataset_location == ("s3://test-bucket/" "custom/dataset/offset/")
+    assert convention.dataset_location == "s3://test-bucket/custom/dataset/offset/"
 
     # Custom product name?
     convention.product_name = "my_custom_product"
-    assert convention.metadata_file == Path(
-        "my_custom_product-2-3_023543_2013-02-03.odc-metadata.yaml"
+    assert (
+        convention.metadata_file
+        == "my_custom_product-2-3_023543_2013-02-03.odc-metadata.yaml"
     )
 
 
@@ -410,13 +413,13 @@ def test_local_path_naming(tmp_path: Path):
 
     convention = namer(p, conventions="dea", collection_prefix=Path("/my/collections"))
     assert convention.dataset_location == (
-        "file:///my/collections/" "ga_s2am_tester_1/023/543/2013/02/03/"
+        "file:///my/collections/ga_s2am_tester_1/023/543/2013/02/03/"
     )
     assert convention.resolve_file(convention.metadata_file)
 
     # We can get it as a pathlib object
     assert convention.dataset_path == Path(
-        "/my/collections/" "ga_s2am_tester_1/023/543/2013/02/03"
+        "/my/collections/ga_s2am_tester_1/023/543/2013/02/03"
     )
 
 


### PR DESCRIPTION
They're URL-components, so Path's aren't strictly correct, and these fields are so central that it will be a hassle to add logic for  both types in every single location that touches them.