### PR TITLE
Allow `eo3-validate` to load products from Explorer or ODC

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ them validated.
 You can also run with `--thorough` to have it open imagery files too, checking
 their properties match the product (nodata, dtype etc)
 
-
     ❯ eo3-validate --help
     Usage: eo3-validate [OPTIONS] [PATHS]...
     
@@ -110,6 +109,9 @@ their properties match the product (nodata, dtype etc)
                                       (deliberately) allowed by ODC, but often a
                                       mistake. This flag disables the warning.
     
+      --from-explorer TEXT            Read all product definitions from the given
+                                      Explorer URL
+
       -q, --quiet                     Only print problems, one per line
       --help                          Show this message and exit.
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,13 @@ their properties match the product (nodata, dtype etc)
                                       (deliberately) allowed by ODC, but often a
                                       mistake. This flag disables the warning.
     
-      --from-explorer TEXT            Read all product definitions from the given
-                                      Explorer URL
-
+      --explorer-url TEXT             Use product definitions from the given
+                                      Explorer URL to validate datasets. Eg:
+                                      "https://explorer.dea.ga.gov.au/"
+    
+      --odc                           Use product definitions from datacube to
+                                      validate datasets
+    
       -q, --quiet                     Only print problems, one per line
       --help                          Show this message and exit.
 


### PR DESCRIPTION
```
❯ eo3-validate --explorer-url https://explorer-aws.dea.ga.gov.au [datasets...]
❯ eo3-validate --odc [datasets...]
```
... will load the products from ODC or Explorer before validating your datasets against them.