### PR TITLE
Allow for more vectorisation options

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -295,7 +295,11 @@ all measurements.
 By default, the assembler will create this geometry by reading the pixels from your
 measurements, and calculate a geometry vector on completion.
 
-If you want to avoid these reads and calculations, you can set the geometry manually::
+This can be configured by setting the :attr:`p.valid_data_method <eodatasets3.DatasetPrepare.valid_data_method>`
+to a different :class:`ValidDataMethod<eodatasets3.ValidDataMethod>` value.
+
+But you may want to avoid these reads and calculations entirely, in which case you can set
+a geometry yourself::
 
     p.geometry = my_shapely_polygon
 
@@ -736,4 +740,5 @@ Misc Types
 
 .. automodule:: eodatasets3
    :members:
+   :member-order: bysource
    :exclude-members: DatasetAssembler, DatasetPrepare, NamingConventions, namer

--- a/eodatasets3/__init__.py
+++ b/eodatasets3/__init__.py
@@ -1,6 +1,6 @@
 from ._version import get_versions
 from .assemble import DatasetAssembler, DatasetPrepare, IfExists, IncompleteDatasetError
-from .images import GridSpec
+from .images import GridSpec, ValidDataMethod
 from .model import DatasetDoc
 from .names import NamingConventions, namer
 from .properties import Eo3Dict
@@ -21,5 +21,6 @@ __all__ = (
     "NamingConventions",
     "namer",
     "REPO_URL",
+    "ValidDataMethod",
     "__version__",
 )

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -813,7 +813,6 @@ class DatasetPrepare(Eo3Interface):
         validate_correctness: bool = True,
         sort_measurements: bool = True,
         expect_geometry: bool = True,
-        fill_geometry_holes: bool = True,
     ) -> DatasetDoc:
         """
         Create the metadata doc as an in-memory :class:`eodatasets3.DatasetDoc` instance.

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -23,6 +23,15 @@ from shapely.geometry.base import BaseGeometry
 import eodatasets3
 from eodatasets3 import documents, images, serialise, validate
 from eodatasets3.documents import find_and_read_documents
+from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler, ValidDataMethod
+from eodatasets3.model import (
+    DatasetDoc,
+    ProductDoc,
+    Location,
+    AccessoryDoc,
+)
+from eodatasets3.names import NamingConventions, namer, resolve_location, dc_uris
+from eodatasets3.properties import Eo3Interface, Eo3Dict
 from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler
 from eodatasets3.model import AccessoryDoc, DatasetDoc, Location, ProductDoc
 from eodatasets3.names import NamingConventions, dc_uris, namer, resolve_location
@@ -278,6 +287,9 @@ class DatasetPrepare(Eo3Interface):
             raise ValueError(
                 f"Provided collection location doesn't exist: {collection_location}"
             )
+
+        #: How to calculate the valid data polygon?
+        self.valid_data_method: ValidDataMethod = ValidDataMethod.filled
 
         if not dataset:
             dataset = DatasetDoc()
@@ -837,7 +849,7 @@ class DatasetPrepare(Eo3Interface):
         crs, grid_docs, measurement_docs = self._measurements.as_geo_docs()
 
         valid_data = self.geometry or self._measurements.consume_and_get_valid_data(
-            fill_holes=fill_geometry_holes
+            valid_data_method=self.valid_data_method
         )
 
         # Avoid the messiness of different empty collection types.

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -792,6 +792,7 @@ class DatasetPrepare(Eo3Interface):
         validate_correctness: bool = True,
         sort_measurements: bool = True,
         expect_geometry: bool = True,
+        fill_geometry_holes: bool = True,
     ) -> DatasetDoc:
         """
         Create the metadata doc as an in-memory :class:`eodatasets3.DatasetDoc` instance.
@@ -835,7 +836,9 @@ class DatasetPrepare(Eo3Interface):
 
         crs, grid_docs, measurement_docs = self._measurements.as_geo_docs()
 
-        valid_data = self.geometry or self._measurements.consume_and_get_valid_data()
+        valid_data = self.geometry or self._measurements.consume_and_get_valid_data(
+            fill_holes=fill_geometry_holes
+        )
 
         # Avoid the messiness of different empty collection types.
         # (to have a non-null geometry we'd also need non-null grids and crses)

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -24,15 +24,6 @@ import eodatasets3
 from eodatasets3 import documents, images, serialise, validate
 from eodatasets3.documents import find_and_read_documents
 from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler, ValidDataMethod
-from eodatasets3.model import (
-    DatasetDoc,
-    ProductDoc,
-    Location,
-    AccessoryDoc,
-)
-from eodatasets3.names import NamingConventions, namer, resolve_location, dc_uris
-from eodatasets3.properties import Eo3Interface, Eo3Dict
-from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler
 from eodatasets3.model import AccessoryDoc, DatasetDoc, Location, ProductDoc
 from eodatasets3.names import NamingConventions, dc_uris, namer, resolve_location
 from eodatasets3.properties import Eo3Dict, Eo3Interface
@@ -290,15 +281,15 @@ class DatasetPrepare(Eo3Interface):
 
         #: What method to use to calculate the valid data geometry?
         #:
-        #: Defaults to :attr:`eodatasets3.ValidDataMethod.filled`
+        #: Defaults to :attr:`eodatasets3.ValidDataMethod.thorough`
         #:
         #: You may change this property before finishing your package.
         #:
         #: Eg::
         #:
-        #:    p.valid_data_method = ValidDataMethod.vanilla
+        #:    p.valid_data_method = ValidDataMethod.filled
         #:
-        self.valid_data_method: ValidDataMethod = ValidDataMethod.filled
+        self.valid_data_method: ValidDataMethod = ValidDataMethod.thorough
 
         if not dataset:
             dataset = DatasetDoc()

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -288,7 +288,16 @@ class DatasetPrepare(Eo3Interface):
                 f"Provided collection location doesn't exist: {collection_location}"
             )
 
-        #: How to calculate the valid data polygon?
+        #: What method to use to calculate the valid data geometry?
+        #:
+        #: Defaults to :attr:`eodatasets3.ValidDataMethod.filled`
+        #:
+        #: You may change this property before finishing your package.
+        #:
+        #: Eg::
+        #:
+        #:    p.valid_data_method = ValidDataMethod.vanilla
+        #:
         self.valid_data_method: ValidDataMethod = ValidDataMethod.filled
 
         if not dataset:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ EXTRAS_REQUIRE = {
     # If packaging ard/wagl.
     "wagl": ["h5py"],
     # The (legacy) prepare scripts
-    "ancillary": ["scipy", "checksumdir", "netCDF4"],
+    "ancillary": ["checksumdir", "netCDF4"],
+    # Optional valid-data poly handling methods
+    "algorithms": ["scikit-image"],
 }
 EXTRAS_REQUIRE["all"] = list(chain(EXTRAS_REQUIRE.values()))
 # Tests need all those optionals too.

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "pyproj",
         "rasterio",
         "ruamel.yaml",
+        "scipy",
         "shapely",
         "structlog",
         "xarray",


### PR DESCRIPTION
~**note**: only an experiment for now: we'll see how it affects things~. Ready to merge, I think, as it allows new options but should not change existing default behaviour.

This avoids a common issue that surprises people: observations with small holes (such as specklings of nodata pixels, as seen in #184) can blow out the CPU usage of geometry calculation.

Valid data is allowed to be bigger than the actual image, and none of our use cases benefit from holes, so why not fill them
by default?

(this makes scipy a core dependency, rather than optional)

## Options Added

This PR makes valid-data calculation method an enum.

1. `thorough`: Vectorize the valid pixel mask as-is. (**the default**)
2. `filled`: Fill holes in the valid pixel mask before vectorizing. (**a potential new default**. but I haven't changed it in this PR to avoid potential compatibility issues.)
        (Much faster than vanilla if there’s many small nodata holes, as they cause many tiny polygons that are later removed by geom simplification. But mildly slower when no holes exist: ~1 sec.)
3. `convex_hull`:  (suggested by Imam)
        Take convex-hull of valid pixel mask before vectorizing.
        This is much slower than filled, but will work in cases where you have a lot of internal geometry that aren’t holes. Such as SLC-Off Landsat 7 data.
        Requires extra ‘scikit-image’ dependency.
4. `bounds` (a "do nothing" option)
        Use the image file bounds, ignoring actual pixel values.


### Remaining Questions

Is an enum an okay API? Maybe they'll want parameters in the future? (eg. "number of pixels to dilate by"). But maybe in those cases we should just let them set their own `Callable` to mess with the mask themselves in more advanced ways?

### Todo

- [ ] ~Test on more of the existing products. Could `filled` be used universally instead of `thorough`?~
      - (Our integration tests are all scaled down tiny images, so aren't a good reflection of impact)
      - *Decided to leave potential default-behaviour change for a future PR*
- [x] Maybe add "geometry calc method" as a config enum? (Possible options: filled-holes, normal, full-image-bounds...)
- [x] Mention in docs the valid-data-methods
- [ ] ~If `method==bounds`, the `note_measurement` methods could avoid reading any pixels at all. Currently, this option just avoids the shape calculation.~
   - *Performance optimisation can be left for a future PR*