### PR TITLE
Feature/odc stats integration

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -636,7 +636,9 @@ class DatasetPrepare(Eo3Interface):
                     ) from v
             self._dataset.lineage.setdefault(classifier, []).append(dataset_id)
 
-    def _inherit_properties_from(self, source_dataset: DatasetDoc, inherit_skip_properties: Optional[str] = None):
+    def _inherit_properties_from(
+        self, source_dataset: DatasetDoc, inherit_skip_properties: Optional[str] = None
+    ):
 
         if not inherit_skip_properties:
             # change the inherit_skip_properties to [] if it is None. Make the 'in list check' easier.

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -640,11 +640,12 @@ class DatasetPrepare(Eo3Interface):
 
         if not inherit_skip_properties:
             # change the inherit_skip_properties to [] if it is None. Make the 'in list check' easier.
-            inherit_skip_properties = [] 
+            inherit_skip_properties = []
 
         for name in self.INHERITABLE_PROPERTIES:
-            if name in inherit_skip_properties: 
-                continue # if we plan to skip this property, skip it immediately.
+            if name in inherit_skip_properties:
+                # if we plan to skip this property, skip it immediately.
+                continue
 
             if name not in source_dataset.properties:
                 continue

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -576,6 +576,10 @@ class DatasetPrepare(Eo3Interface):
                             data, which can be very computationally expensive e.g. Landsat 7
                             striped data, use the valid data geometry from this source dataset.
 
+        :param inherit_skip_properties: An extra list of property names that should not be copied.
+                                        This is useful when generating summaries which combine multiple
+                                        input source datasets.
+
         See :meth:`.add_source_path` if you have a filepath reference instead of a document.
 
         """
@@ -637,7 +641,9 @@ class DatasetPrepare(Eo3Interface):
             self._dataset.lineage.setdefault(classifier, []).append(dataset_id)
 
     def _inherit_properties_from(
-        self, source_dataset: DatasetDoc, inherit_skip_properties: Optional[str] = None
+        self,
+        source_dataset: DatasetDoc,
+        inherit_skip_properties: Optional[List[str]] = None,
     ):
 
         if not inherit_skip_properties:


### PR DESCRIPTION
Add a feature which allows specifying a list of extra property names that shouldn't be inherited when adding source datasets.

This is required for summary datasets. They have a large list of source datasets, and need to not inherit per dataset metadata like GQA, extents and more. E.g. gqa:mean_x.


Add an `inherit_skip_properties` argument to `DatasetPrepare.add_source_dataset()`, of type `Optional[List[str]]`.
