### PR TITLE
Add 'provisional' for new DEA naming conventions

### DIFF
--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -39,6 +39,11 @@ class LazyProductName:
                 f"{c.platform_abbreviated or ''}{instrument or ''}",
                 c.metadata.product_family,
                 (
+                    c.metadata.product_maturity
+                    if c.metadata.product_maturity != "stable"
+                    else None
+                ),
+                (
                     f"{c.displayed_collection_number}"
                     if (self.include_collection and c.displayed_collection_number)
                     else None

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -294,6 +294,7 @@ class Eo3Dict(collections.abc.MutableMapping):
     KNOWN_PROPERTIES: Mapping[str, Optional[NormaliseValueFn]] = {
         "datetime": datetime_type,
         "dea:dataset_maturity": of_enum_type(("final", "interim", "nrt"), lower=True),
+        "dea:product_maturity": of_enum_type(("stable", "provisional"), lower=True),
         "dtr:end_datetime": datetime_type,
         "dtr:start_datetime": datetime_type,
         "eo:azimuth": float,
@@ -696,6 +697,17 @@ class Eo3Interface:
     @maturity.setter
     def maturity(self, value):
         self.properties["dea:dataset_maturity"] = value
+
+    @property
+    def product_maturity(self) -> str:
+        """
+        Classification: is this a 'provisional' or 'stable' release of the product?
+        """
+        return self.properties.get("dea:product_maturity")
+
+    @product_maturity.setter
+    def product_maturity(self, value):
+        self.properties["dea:product_maturity"] = value
 
     # Note that giving a method the name 'datetime' will override the 'datetime' type
     # for class-level declarations (ie, for any types on functions!)

--- a/eodatasets3/scripts/packagewagl.py
+++ b/eodatasets3/scripts/packagewagl.py
@@ -15,6 +15,8 @@ from click import secho
 from eodatasets3 import wagl
 from eodatasets3.ui import PathPath
 
+DEFAULT_MATURITY = wagl.ProductMaturity.stable
+
 
 @click.command(help=__doc__)
 @click.option(
@@ -46,6 +48,13 @@ from eodatasets3.ui import PathPath
     default=True,
 )
 @click.option(
+    "--product-maturity",
+    type=click.Choice(wagl.ProductMaturity.__members__, case_sensitive=False),
+    help=f"Product maturity status (default: {DEFAULT_MATURITY.name})",
+    default=DEFAULT_MATURITY.name,
+    callback=lambda c, p, v: wagl.ProductMaturity[v.lower()] if v else None,
+)
+@click.option(
     "--with-oa/--no-oa",
     "with_oa",
     help="Include observation attributes (default: true)",
@@ -73,6 +82,7 @@ def run(
     h5_file: Path,
     products: Sequence[str],
     with_oa: bool,
+    product_maturity: wagl.ProductMaturity,
     allow_missing_provenance: bool,
     oa_resolution: Optional[float],
 ):
@@ -101,6 +111,7 @@ def run(
                 dataset_id, dataset_path = wagl.package(
                     out_directory=output,
                     granule=granule,
+                    product_maturity=product_maturity,
                     included_products=products,
                     include_oa=with_oa,
                     oa_resolution=oa_resolution,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,6 +59,9 @@ def assert_file_structure(folder, expected_structure, root=""):
     optional_filenames = set(
         name for name, option in expected_structure.items() if option == "optional"
     )
+    assert (
+        folder.exists()
+    ), f"Expected base folder doesn't even exist! {folder.as_posix()!r}"
 
     actual_filenames = {f.name for f in folder.iterdir()}
 

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -79,6 +79,29 @@ def test_dea_s2_derivate_names(tmp_path: Path):
     )
 
 
+def test_minimal_provisional_dea_dataset(tmp_path: Path):
+    assert_names_match(
+        tmp_path,
+        conventions="dea",
+        properties={
+            "eo:platform": "landsat-8",
+            "eo:instrument": "OLI_TIRS",
+            "datetime": datetime(2020, 5, 26),
+            "odc:product_family": "ufo-observations",
+            "odc:processing_datetime": "2018-11-05T12:23:23",
+            "odc:dataset_version": "1.0.0",
+            "odc:producer": "ga.gov.au",
+            "odc:region_code": "088080",
+            "landsat:landsat_scene_id": "LC80880802020146LGN00",
+            # Provisional! It'll be added to the path, right?
+            "dea:product_maturity": "provisional",
+        },
+        expect_label="ga_ls8c_ufo_observations_provisional_1-0-0_088080_2020-05-26",
+        expect_metadata_path="ga_ls8c_ufo_observations_provisional_1/088/080/2020/05/26/"
+        "ga_ls8c_ufo_observations_provisional_1-0-0_088080_2020-05-26.odc-metadata.yaml",
+    )
+
+
 def test_minimal_s2_dataset_normal(tmp_path: Path):
     """A minimal dataset with sentinel platform/instrument"""
     with DatasetAssembler(tmp_path) as p:
@@ -234,6 +257,8 @@ def test_dea_interim_folder_calculation(tmp_path: Path):
     """
     with DatasetAssembler(tmp_path, naming_conventions="dea") as p:
         p.platform = "landsat-7"
+        # Should not end up in the path, as it's the default:
+        p.product_maturity = "stable"
         p.instrument = "ETM+"
         p.datetime = datetime(1998, 7, 30)
         p.product_family = "frogs"


### PR DESCRIPTION
As requested by Simon, matching the updated naming conventions document.

```
p.product_maturity = 'provisional'
```
or (identically)
```
p.properties[“dea:product_maturity”] = 'provisional'
```
When not specified, maturity is assumed to be `'stable'`. Non-`stable` maturities are added to the product name & paths:
```
/ga_ls8c_ard_provisional_3/096/095/2000/10/01/ga_ls8c_ard_provisional_3-0-0_096095_2000-10-01_final.odc-metadata.yaml
```

Includes tests for provisional case. The other tests already cover non-provisional products (they are unchanged).