### PR TITLE
Fix manually-constructed property normalisation

### DIFF
--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -340,7 +340,7 @@ class Eo3Dict(collections.abc.MutableMapping):
         self._props = properties
         # We normalise the properties they gave us.
         if normalise_input:
-            for key in self._props:
+            for key in list(self._props):
                 self.normalise_and_set(key, self._props[key], expect_override=True)
         self._finished_init_ = True
 


### PR DESCRIPTION
Fixes exception seen by Alchemist on the dev branch, as reported by @james-blitzm.

(the included test reproduces it)

```python
Traceback (most recent call last):
  File "/env/bin/datacube-alchemist", line 33, in <module>
    sys.exit(load_entry_point('datacube-alchemist', 'console_scripts', 'datacube-alchemist')())
  File "/code/datacube_alchemist/cli.py", line 67, in cli_with_envvar_handling
    cli(auto_envvar_prefix="ALCHEMIST")
  File "/env/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/env/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/env/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/env/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/code/datacube_alchemist/cli.py", line 94, in run_one
    alchemist.execute_task(task, dryrun)
  File "/code/datacube_alchemist/worker.py", line 461, in execute_task
    source_doc = _munge_dataset_to_eo3(task.dataset)
  File "/code/datacube_alchemist/_utils.py", line 143, in _munge_dataset_to_eo3
    return _convert_eo_plus(ds)
  File "/code/datacube_alchemist/_utils.py", line 194, in _convert_eo_plus
    properties = StacPropertyView(
  File "/env/lib/python3.8/site-packages/eodatasets3/properties.py", line 444, in __init__
    super().__init__(properties)
  File "/env/lib/python3.8/site-packages/eodatasets3/properties.py", line 343, in __init__
    for key in self._props:
RuntimeError: dictionary changed size during iteration
```