### PR TITLE
Add `p.collection_location` backwards compat property

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -442,6 +442,17 @@ class DatasetPrepare(Eo3Interface):
         ...
 
     @property
+    def collection_location(self) -> Path:
+        # Backward compat method. No docstring to avoid sphinx visibility.
+        return self.names.collection_path
+
+    @collection_location.setter
+    def collection_location(self, val: Path):
+        # Backward compat method. No docstring to avoid sphinx visibility.
+        # Previously, people could set the collection using this property, and it was a Path
+        self.names.collection_prefix = resolve_location(val)
+
+    @property
     def dataset_id(self) -> uuid.UUID:
         return self._dataset.id
 


### PR DESCRIPTION
We didn't realise users were setting this property outside of the constructor, but Alchemist does: https://github.com/opendatacube/datacube-alchemist/blob/917df44fef2d48a1a5f07a5ac8c4bf0cfde0c5f2/datacube_alchemist/worker.py#L499

Adds a backwards compatibility shim.