### PR TITLE
Handle NaNs in stac documents

### DIFF
--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 import click
 from click import echo, style
+from datacube.utils import jsonify_document
 
 import eodatasets3.stac as eo3stac
 from eodatasets3 import serialise
@@ -58,7 +59,7 @@ def run(
             eo3stac.validate_item(item_doc)
 
         with output_path.open("w") as f:
-            json.dump(item_doc, f, indent=4, default=json_fallback)
+            json.dump(jsonify_document(item_doc), f, indent=4, default=json_fallback)
 
         if verbose:
             echo(f'Wrote {style(output_path.as_posix(), "green")}')

--- a/tests/common.py
+++ b/tests/common.py
@@ -183,6 +183,9 @@ def format_doc_diffs(left: Dict, right: Dict) -> Iterable[str]:
         for offset in doc_diffs.tree["dictionary_item_removed"].items:
             offset: DiffLevel
             out.append(f"    {clean_offset(offset.path())} = {repr(offset.t1)}")
+    # Anything we missed from the (sometimes changing) diff api?
+    if len(out) == 1:
+        out.append(repr(doc_diffs))
 
     # If pytest verbose:
     out.extend(("Full output document: ", repr(left)))

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml
@@ -52,7 +52,7 @@ properties:
   gqa:abs_x: 0.28
   gqa:abs_xy: 0.4
   gqa:abs_y: 0.28
-  gqa:cep90: 0.4
+  gqa:cep90: .nan
   gqa:iterative_mean_x: 0.03
   gqa:iterative_mean_xy: 0.12
   gqa:iterative_mean_y: 0.12

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -27,7 +27,7 @@
       "gqa:abs_x": 0.28,
       "gqa:abs_xy": 0.4,
       "gqa:abs_y": 0.28,
-      "gqa:cep90": 0.4,
+      "gqa:cep90": "NaN",
       "gqa:iterative_mean_x": 0.03,
       "gqa:iterative_mean_xy": 0.12,
       "gqa:iterative_mean_y": 0.12,


### PR DESCRIPTION
As reported by @uchchwhash 

We were outputting raw `NaN` values in our stac json document, which is invalid json.

Convert them to strings using ODC's standard method.

Updated the test conversion to include a NaN.

 (... but I'm surprised python's default json module quietly outputs invalid json)