### PR TITLE
Add GH-Actions formatting for eo3-validate warnings

### DIFF
--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -1015,6 +1015,15 @@ def display_message(message: ValidationMessage, file_offset: str):
     This will use colour if available (interactive use), and Github Actions codes if available (for annotating warnings
     against the file)
     """
+    hint = ""
+    if message.hint:
+        # Indent the hint if it's multi-line.
+        if "\n" in message.hint:
+            hint = "\t\tHint:\n"
+            hint += indent(message.hint, "\t\t" + (" " * 5))
+        else:
+            hint = f"\t\t(Hint: {message.hint})"
+
     # Are we in Github Actions?
     # Send any warnings/errors in its custom format
     if "GITHUB_ACTIONS" in os.environ and not FORCE_PLAIN_OUTPUT:
@@ -1023,9 +1032,9 @@ def display_message(message: ValidationMessage, file_offset: str):
         else:
             code = "::warning"
 
-        text = message.reason
-        if message.hint:
-            text += f"\n\nHint:\n{message.hint})"
+        text = f"{message.reason}"
+        if hint:
+            text += f"\n{hint}"
         # URL-Encode any newlines
         text = text.replace("\n", "%0A")
         echo(f"{code} file={file_offset}::{text}")
@@ -1038,12 +1047,8 @@ def display_message(message: ValidationMessage, file_offset: str):
         }
         displayable_code = style(f"{message.code}", **s[message.level], bold=True)
         echo(f"\t{message.level.name[0].upper()} {displayable_code} {message.reason}")
-        if message.hint:
-            if "\n" in message.hint:
-                echo("\t\tHint:")
-                echo(indent(message.hint, "\t\t" + (" " * 5)))
-            else:
-                echo(f'\t\t({style("Hint")}: {message.hint})')
+        if hint:
+            echo(hint)
 
 
 def _load_remote_product_definitions(

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -9,7 +9,6 @@ import rasterio
 from click.testing import CliRunner, Result
 from rasterio.io import DatasetWriter
 
-import eodatasets3.validate
 from eodatasets3 import serialise, validate
 from eodatasets3.model import DatasetDoc
 
@@ -17,15 +16,6 @@ from eodatasets3.model import DatasetDoc
 from eodatasets3.validate import DocKind, guess_kind_from_contents, filename_doc_kind
 
 Doc = Union[Dict, Path]
-
-
-@pytest.fixture(autouse=True)
-def force_plain_output():
-    # We don't want this defaulting to Github Actions formatting when running our
-    # own tests on the plain output.
-    eodatasets3.validate.FORCE_PLAIN_OUTPUT = True
-    yield
-    eodatasets3.validate.FORCE_PLAIN_OUTPUT = False
 
 
 @pytest.fixture()
@@ -229,7 +219,7 @@ class ValidateRunner:
     ):
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
-        args = ()
+        args = ("-f", "plain")
 
         if self.quiet:
             args += ("-q",)

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -9,6 +9,7 @@ import rasterio
 from click.testing import CliRunner, Result
 from rasterio.io import DatasetWriter
 
+import eodatasets3.validate
 from eodatasets3 import serialise, validate
 from eodatasets3.model import DatasetDoc
 
@@ -16,6 +17,15 @@ from eodatasets3.model import DatasetDoc
 from eodatasets3.validate import DocKind, guess_kind_from_contents, filename_doc_kind
 
 Doc = Union[Dict, Path]
+
+
+@pytest.fixture(autouse=True)
+def force_plain_output():
+    # We don't want this defaulting to Github Actions formatting when running our
+    # own tests on the plain output.
+    eodatasets3.validate.FORCE_PLAIN_OUTPUT = True
+    yield
+    eodatasets3.validate.FORCE_PLAIN_OUTPUT = False
 
 
 @pytest.fixture()


### PR DESCRIPTION
This way, lint warnings and errors will display in PRs alongside the file.

(which is much nicer than digging into CI logs for failure reasons)

Eg.

![Screenshot from 2021-09-08 10-56-54](https://user-images.githubusercontent.com/25688/132428598-764dfeae-ac0c-4b2b-b6a5-71497c68b8cc.png)
