### PR TITLE
Enable the Bandit security checker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-          username: gadockersvc
+          username: ${{ secrets.GADOCKERSVC_USERNAME }}
           password: ${{ secrets.GADOCKERSVC_PASSWORD }}
 
       - name: Build and push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: tests/integration/data
 
 repos:
     - repo: https://github.com/ambv/black
-      rev: 21.7b0
+      rev: 21.8b0
       hooks:
           - id: black
     - repo: https://gitlab.com/pycqa/flake8
@@ -21,6 +21,12 @@ repos:
                   - flake8-pep3101 # Don't use old string % formatting
                   - flake8-pytest # Use plain assert, not unittest assertions
                   - pep8-naming # Follow pep8 naming rules (eg. function names lowercase)
+    # Common Python security checks. (this is complementary to dlint in flake8)
+    - repo: https://github.com/PyCQA/bandit
+      rev: '1.7.0'
+      hooks:
+        - id: bandit
+          exclude: '^tests/|_version.py|versioneer.py'
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.0.1
       hooks:

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1701,6 +1701,9 @@ class DatasetAssembler(DatasetPrepare):
                 )
 
         target_metadata_path = self._target_metadata_path()
-        assert target_metadata_path.exists()
+        if not target_metadata_path.exists():
+            raise RuntimeError(
+                f"Internal error: expected metadata path result: {target_metadata_path}"
+            )
         self._is_completed = True
         return dataset.id, target_metadata_path

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -392,8 +392,10 @@ def prepare_and_write(
         naming_conventions="dea",
     ) as p:
         if source_telemetry:
-            # Only GA's data has source telemetry...
-            assert producer == "ga.gov.au"
+            if producer != "ga.gov.au":
+                raise NotImplementedError(
+                    "Only GA's L1 data is expected to have telemetry source data?"
+                )
             p.add_source_path(source_telemetry)
 
         p.platform = mtl_doc[coll_map["image_attributes"]]["spacecraft_id"]

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -1126,7 +1126,7 @@ def _load_explorer_product_definitions(
     """
     product_urls = [
         urljoin(explorer_url, f"/products/{name.strip()}.odc-product.yaml")
-        for name in urlopen(urljoin(explorer_url, "products.txt"))
+        for name in urlopen(urljoin(explorer_url, "products.txt"))  # nosec
         .read()
         .decode("utf-8")
         .split("\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,7 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.bandit]
+
+exclude = 'tests'


### PR DESCRIPTION
We already run the dlint checker, but the dlint readme says they both have their own unique advantages, so can them side-by-side.