### PR TITLE
Use `shed` rather than custom black+isort+etc setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,11 @@
 exclude: tests/integration/data
 
 repos:
-    - repo: https://github.com/ambv/black
-      rev: 21.8b0
+    # Normalise all Python code. (Black + isort + pyupgrade + autoflake)
+    - repo: https://github.com/Zac-HD/shed
+      rev: 0.3.10
       hooks:
-          - id: black
+      - id: shed
     - repo: https://gitlab.com/pycqa/flake8
       # flake8 version should match .travis.yml
       rev: 3.9.2

--- a/README.md
+++ b/README.md
@@ -19,38 +19,39 @@ Python 3.6+ is supported.
 The assembler api aims to make it easy to write datasets.
 
 ```python
-    from eodatasets3 import DatasetAssembler
-    from datetime import datetime
-    from pathlib import Path
+from datetime import datetime
+from pathlib import Path
 
-    with DatasetAssembler(
-            Path('/some/output/collection/path'),
-            naming_conventions='default') as p:
+from eodatasets3 import DatasetAssembler
 
-        # Add some common metadata fields.
-        p.platform = 'landsat-7'
-        p.instrument = 'ETM'
-        p.datetime = datetime(2019, 7, 4, 13, 7, 5)
-        p.processed_now()
+with DatasetAssembler(
+    Path("/some/output/collection/path"), naming_conventions="default"
+) as p:
 
-        # Support for custom metadata fields
-        p.properties['fmask:cloud_shadow'] = 42.0
+    # Add some common metadata fields.
+    p.platform = "landsat-7"
+    p.instrument = "ETM"
+    p.datetime = datetime(2019, 7, 4, 13, 7, 5)
+    p.processed_now()
 
-        # If you have a source dataset, you can include it as provenance.
-        # Assembler can also copy common metadata properties from it.
-        # (... so we didn't need to set the "platform" above!)
-        p.add_source_path(source_dataset, auto_inherit_properties=True)
+    # Support for custom metadata fields
+    p.properties["fmask:cloud_shadow"] = 42.0
 
-        # Write measurements. They can be from numpy arrays, open rasterio datasets,
-        # file paths, ODC Datasets...
-        p.write_measurement("red", red_path)
-        ...  # now write more measurements
+    # If you have a source dataset, you can include it as provenance.
+    # Assembler can also copy common metadata properties from it.
+    # (... so we didn't need to set the "platform" above!)
+    p.add_source_path(source_dataset, auto_inherit_properties=True)
 
-        # Create a jpg thumbnail image using the measurements we've written
-        p.write_thumbnail(red="swir1", green="swir2", blue="red")
+    # Write measurements. They can be from numpy arrays, open rasterio datasets,
+    # file paths, ODC Datasets...
+    p.write_measurement("red", red_path)
+    ...  # now write more measurements
 
-        # Validate the dataset and write it to the destination folder atomically.
-        p.done()
+    # Create a jpg thumbnail image using the measurements we've written
+    p.write_thumbnail(red="swir1", green="swir2", blue="red")
+
+    # Validate the dataset and write it to the destination folder atomically.
+    p.done()
 ```
 
 The Assembler will write a folder of [COG](https://www.cogeo.org/) imagery, an [eo3](#open-data-cube-compatibility)

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Require a '--runslow' argument to run the tests with a @slow annotation.
 
 import pytest

--- a/eodatasets3/__init__.py
+++ b/eodatasets3/__init__.py
@@ -1,14 +1,9 @@
-# coding=utf-8
-
-from __future__ import absolute_import
-
 from ._version import get_versions
 from .assemble import DatasetAssembler, DatasetPrepare, IfExists, IncompleteDatasetError
 from .images import GridSpec
 from .model import DatasetDoc
+from .names import NamingConventions, namer
 from .properties import Eo3Dict
-
-from .names import namer, NamingConventions
 
 REPO_URL = "https://github.com/GeoscienceAustralia/eo-datasets.git"
 

--- a/eodatasets3/_version.py
+++ b/eodatasets3/_version.py
@@ -85,7 +85,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
                 stderr=(subprocess.PIPE if hide_stderr else None),
             )
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
@@ -95,7 +95,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -148,7 +148,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -163,7 +163,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["date"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -187,11 +187,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -200,7 +200,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r"\d", r)])
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -303,7 +303,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+            pieces["error"] = "tag '{}' doesn't start with prefix '{}'".format(
                 full_tag,
                 tag_prefix,
             )

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -7,9 +7,9 @@ import uuid
 import warnings
 from copy import deepcopy
 from enum import Enum, auto
-from pathlib import Path, PurePath, PosixPath
+from pathlib import Path, PosixPath, PurePath
 from textwrap import dedent
-from typing import Dict, List, Optional, Tuple, Generator, Any, Iterable, Union
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
 import numpy
@@ -21,17 +21,12 @@ from rasterio.enums import Resampling
 from shapely.geometry.base import BaseGeometry
 
 import eodatasets3
-from eodatasets3 import serialise, validate, images, documents
+from eodatasets3 import documents, images, serialise, validate
 from eodatasets3.documents import find_and_read_documents
 from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler
-from eodatasets3.model import (
-    DatasetDoc,
-    ProductDoc,
-    Location,
-    AccessoryDoc,
-)
-from eodatasets3.names import NamingConventions, namer, resolve_location, dc_uris
-from eodatasets3.properties import Eo3Interface, Eo3Dict
+from eodatasets3.model import AccessoryDoc, DatasetDoc, Location, ProductDoc
+from eodatasets3.names import NamingConventions, dc_uris, namer, resolve_location
+from eodatasets3.properties import Eo3Dict, Eo3Interface
 from eodatasets3.validate import Level, ValidationMessage
 from eodatasets3.verify import PackageChecksum
 
@@ -468,9 +463,9 @@ class DatasetPrepare(Eo3Interface):
 
     @property
     def measurements(self) -> Dict[str, Tuple[GridSpec, Path]]:
-        return dict(
-            (name, (grid, path)) for grid, name, path in self._measurements.iter_paths()
-        )
+        return {
+            name: (grid, path) for grid, name, path in self._measurements.iter_paths()
+        }
 
     @property
     def label(self) -> Optional[str]:
@@ -1443,7 +1438,7 @@ class DatasetAssembler(DatasetPrepare):
                 )
             )
         rgbs = [self.measurements[b] for b in (red, green, blue)]
-        unique_grids: List[GridSpec] = list(set(grid for grid, path in rgbs))
+        unique_grids: List[GridSpec] = list({grid for grid, path in rgbs})
         if len(unique_grids) != 1:
             raise NotImplementedError(
                 "Thumbnails can only currently be created from measurements of the same grid spec."
@@ -1607,7 +1602,7 @@ class DatasetAssembler(DatasetPrepare):
                 "being ignored).",
                 category=DeprecationWarning,
             )
-            return super(DatasetAssembler, self).done(
+            return super().done(
                 embed_location=embed_location,
                 validate_correctness=validate_correctness,
                 sort_measurements=sort_measurements,

--- a/eodatasets3/documents.py
+++ b/eodatasets3/documents.py
@@ -1,16 +1,13 @@
-# coding=utf-8
 """
 Common methods for UI code.
 """
-from __future__ import absolute_import
 
 import gzip
 import json
 import os
 import posixpath
-from copy import deepcopy
 from pathlib import Path, PurePath
-from typing import Generator, Dict, Tuple
+from typing import Dict, Generator, Tuple
 from urllib.parse import urlparse
 
 from boltons import iterutils
@@ -101,7 +98,7 @@ def new_metadata_path(dataset_path):
         return dataset_path.joinpath("ga-metadata.yaml")
 
     if dataset_path.is_file():
-        return dataset_path.parent.joinpath("{}.ga-md.yaml".format(dataset_path.name))
+        return dataset_path.parent.joinpath(f"{dataset_path.name}.ga-md.yaml")
 
     raise ValueError(f"Unhandled path type for {dataset_path!r}")
 
@@ -119,7 +116,7 @@ def _find_any_metadata_suffix(path):
         return None
 
     if len(existing_paths) > 1:
-        raise ValueError("Multiple matched metadata files: {!r}".format(existing_paths))
+        raise ValueError(f"Multiple matched metadata files: {existing_paths!r}")
 
     return existing_paths[0]
 
@@ -214,6 +211,7 @@ def make_paths_relative(
     """
     Find all pathlib.Path values in a document structure and make them relative to the given path.
 
+    >>> from copy import deepcopy
     >>> base = PurePath('/tmp/basket')
     >>> doc = {'id': 1, 'fruits': [{'apple': PurePath('/tmp/basket/fruits/apple.txt')}]}
     >>> make_paths_relative(doc, base)

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -1,20 +1,31 @@
 import math
+import os
 import string
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path, PurePath
+from typing import (
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import attr
 import numpy
-import os
 import rasterio
 import rasterio.features
 import shapely
 import shapely.affinity
 import shapely.ops
-import sys
-import tempfile
 import xarray
 from affine import Affine
-from collections import defaultdict
-from pathlib import Path, PurePath
 from rasterio import DatasetReader
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
@@ -23,21 +34,9 @@ from rasterio.io import DatasetWriter, MemoryFile
 from rasterio.shutil import copy as rio_copy
 from rasterio.warp import calculate_default_transform, reproject
 from shapely.geometry.base import CAP_STYLE, JOIN_STYLE, BaseGeometry
-from typing import (
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    Set,
-)
 
 from eodatasets3.model import DatasetDoc, GridDoc, MeasurementDoc
 from eodatasets3.properties import FileFormat
-
 
 DEFAULT_OVERVIEWS = (8, 16, 32)
 
@@ -108,7 +107,7 @@ class GridSpec:
     @classmethod
     def from_odc_xarray(cls, dataset: xarray.Dataset) -> "GridSpec":
         """Create from an ODC xarray"""
-        shape = set(v.shape for v in dataset.data_vars.values()).pop()
+        shape = {v.shape for v in dataset.data_vars.values()}.pop()
         return cls(
             shape=shape,
             transform=dataset.geobox.transform,
@@ -614,7 +613,7 @@ class FileWrite:
         # Check for excluded datatypes
         excluded_dtypes = ["int64", "int8", "uint64"]
         if dtype in excluded_dtypes:
-            raise TypeError("Datatype not supported: {dt}".format(dt=dtype))
+            raise TypeError(f"Datatype not supported: {dtype}")
 
         # convert any bools to uin8
         if dtype == "bool":
@@ -634,9 +633,7 @@ class FileWrite:
             lines = shape[1]
             bands = shape[0]
         else:
-            raise IndexError(
-                "Input array is not of 2 or 3 dimensions. Got {dims}".format(dims=ndims)
-            )
+            raise IndexError(f"Input array is not of 2 or 3 dimensions. Got {ndims}")
 
         transform = None
         projection = None

--- a/eodatasets3/metadata/__init__.py
+++ b/eodatasets3/metadata/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/eodatasets3/metadata/valid_region.py
+++ b/eodatasets3/metadata/valid_region.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import sys
 

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple, Dict, Optional, List, Union
+from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 import affine

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -1,21 +1,14 @@
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import (
-    Optional,
-    Sequence,
-    Dict,
-    Mapping,
-    Set,
-    Union,
-)
+from typing import Dict, Mapping, Optional, Sequence, Set, Union
 from urllib.parse import quote, urlparse
 
 import datacube.utils.uris as dc_uris
 
 from eodatasets3 import utils
 from eodatasets3.model import DEA_URI_PREFIX, Location
-from eodatasets3.properties import Eo3Interface, Eo3Dict
+from eodatasets3.properties import Eo3Dict, Eo3Interface
 
 # Needed when packaging zip or tar files.
 dc_uris.register_scheme("zip", "tar")

--- a/eodatasets3/prepare/esri_land_cover_prepare.py
+++ b/eodatasets3/prepare/esri_land_cover_prepare.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import rasterio
 from shapely.geometry import box
 
-from eodatasets3 import DatasetPrepare
-from eodatasets3 import GridSpec
+from eodatasets3 import DatasetPrepare, GridSpec
 
 _ESRI_ID_NAMESPACE = uuid.UUID("88a620e0-6b62-462b-9b23-4027e05898f3")
 

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -8,16 +8,15 @@ import logging
 import os
 import re
 import tarfile
-import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Union, Iterable, Dict, Tuple, Callable, Generator
+from typing import Callable, Dict, Generator, Iterable, List, Optional, Tuple, Union
 
 import click
 import rasterio
 
-from eodatasets3 import serialise, utils, DatasetPrepare
+from eodatasets3 import DatasetPrepare, serialise, utils
 from eodatasets3.properties import FileFormat
 from eodatasets3.ui import PathPath
 
@@ -219,7 +218,7 @@ def get_mtl_content(acquisition_path: Path, root_element=None) -> Tuple[Dict, st
             member = tp.next()
 
     if not acquisition_path.exists():
-        raise RuntimeError("Missing path '{}'".format(acquisition_path))
+        raise RuntimeError(f"Missing path '{acquisition_path}'")
 
     if acquisition_path.is_file() and tarfile.is_tarfile(str(acquisition_path)):
         with tarfile.open(str(acquisition_path), "r") as tp:
@@ -229,9 +228,7 @@ def get_mtl_content(acquisition_path: Path, root_element=None) -> Tuple[Dict, st
                         mtl_doc, file_root_element = read_mtl(fp)
                         return mtl_doc, file_root_element, member.name
             else:
-                raise RuntimeError(
-                    "MTL file not found in {}".format(str(acquisition_path))
-                )
+                raise RuntimeError(f"MTL file not found in {str(acquisition_path)}")
 
     else:
         paths = list(acquisition_path.rglob("*_MTL.txt"))
@@ -566,7 +563,7 @@ def main(
                 continue
 
             logging.info("Processing %s", ds_path)
-            output_yaml = output / "{}.odc-metadata.yaml".format(_dataset_name(ds_path))
+            output_yaml = output / f"{_dataset_name(ds_path)}.odc-metadata.yaml"
 
             if output_yaml.exists():
                 if not overwrite_existing:
@@ -590,6 +587,7 @@ def _normalise_dataset_path(input_path: Path) -> Path:
 
     Translate other inputs (example: the MTL path) to one of the two.
 
+    >>> import tempfile
     >>> tmppath = Path(tempfile.mkdtemp())
     >>> ds_path = tmppath.joinpath('LE07_L1GT_104078_20131209_20161119_01_T1')
     >>> ds_path.mkdir()
@@ -620,11 +618,11 @@ def _normalise_dataset_path(input_path: Path) -> Path:
 
     if not mtl_files:
         raise ValueError(
-            "No MTL files within input path '{}'. Not a dataset?".format(input_path)
+            f"No MTL files within input path '{input_path}'. Not a dataset?"
         )
     if len(mtl_files) > 1:
         raise ValueError(
-            "Multiple MTL files in a single dataset (got path: {})".format(input_path)
+            f"Multiple MTL files in a single dataset (got path: {input_path})"
         )
     return input_path
 

--- a/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
+++ b/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
@@ -2,14 +2,15 @@ import datetime
 import re
 import uuid
 from pathlib import Path
-from typing import Iterable, Dict
-from defusedxml import ElementTree
+from typing import Dict, Iterable
 
 import click
 import rasterio
+from defusedxml import ElementTree
 
 from eodatasets3 import serialise
-from eodatasets3.utils import read_paths_from_file, ItemProvider
+from eodatasets3.utils import ItemProvider, read_paths_from_file
+
 from ..metadata.valid_region import valid_region
 
 MCD43A1_NS = uuid.UUID(hex="80dc431b-fc6c-4e6f-bf08-585eba1d8dc9")

--- a/eodatasets3/prepare/noaa_c_c_prwtreatm_1_prepare.py
+++ b/eodatasets3/prepare/noaa_c_c_prwtreatm_1_prepare.py
@@ -6,7 +6,7 @@ import datetime
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import Iterable, Dict
+from typing import Dict, Iterable
 
 import click
 import rasterio
@@ -14,7 +14,8 @@ import rasterio.crs
 from rasterio.io import DatasetReader
 
 from eodatasets3 import serialise
-from eodatasets3.utils import read_paths_from_file, ItemProvider
+from eodatasets3.utils import ItemProvider, read_paths_from_file
+
 from ..metadata.valid_region import valid_region
 
 NOAA_WATER_VAPOUR_NS = uuid.UUID(hex="857bd048-8c86-4670-a2b4-5dbea26d7692")

--- a/eodatasets3/prepare/sentinel_l1c_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1c_prepare.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 import zipfile
 from pathlib import Path
-from typing import Tuple, Dict, List, Optional, Iterable, Mapping
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
 
 import click
 from defusedxml import minidom

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import datetime
 from enum import Enum, EnumMeta
 from textwrap import dedent
-from typing import Tuple, Dict, Optional, Any, Mapping, Callable, Union, Set
+from typing import Any, Callable, Dict, Mapping, Optional, Set, Tuple, Union
 from urllib.parse import urlencode
 
 import ciso8601
@@ -113,7 +113,7 @@ def normalise_platforms(value: Union[str, list, set]):
     if not isinstance(value, (list, set, tuple)):
         value = value.split(",")
 
-    platforms = sorted(set(s.strip().lower().replace("_", "-") for s in value if s))
+    platforms = sorted({s.strip().lower().replace("_", "-") for s in value if s})
     if not platforms:
         return None
 

--- a/eodatasets3/scripts/__init__.py
+++ b/eodatasets3/scripts/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-
-from __future__ import absolute_import
-
 import logging
 
 

--- a/eodatasets3/scripts/packagewagl.py
+++ b/eodatasets3/scripts/packagewagl.py
@@ -6,7 +6,7 @@ GeoTIFFS (COGs) with datacube metadata using the DEA naming conventions
 for files.
 """
 from pathlib import Path
-from typing import Sequence, Optional
+from typing import Optional, Sequence
 
 import click
 import rasterio
@@ -87,7 +87,7 @@ def run(
     oa_resolution: Optional[float],
 ):
     if products:
-        products = set(p.lower() for p in products)
+        products = {p.lower() for p in products}
     else:
         products = wagl.DEFAULT_PRODUCTS
 

--- a/eodatasets3/scripts/prepare.py
+++ b/eodatasets3/scripts/prepare.py
@@ -1,9 +1,9 @@
 import click
 
 from ..prepare.landsat_l1_prepare import main as landsat_l1
-from ..prepare.sentinel_l1c_prepare import main as sentinel_l1c
 from ..prepare.nasa_c_m_mcd43a1_6_prepare import main as mcd43a1
 from ..prepare.noaa_c_c_prwtreatm_1_prepare import main as prwtr
+from ..prepare.sentinel_l1c_prepare import main as sentinel_l1c
 
 
 @click.group()

--- a/eodatasets3/scripts/recompress.py
+++ b/eodatasets3/scripts/recompress.py
@@ -19,17 +19,17 @@ from contextlib import suppress
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from typing import List, Iterable, Tuple, Callable, IO, Dict
+from typing import IO, Callable, Dict, Iterable, List, Tuple
 
 import click
 import numpy
 import rasterio
 import structlog
 from structlog.processors import (
+    JSONRenderer,
     StackInfoRenderer,
     TimeStamper,
     format_exc_info,
-    JSONRenderer,
 )
 
 from eodatasets3.ui import PathPath

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from functools import partial
 from pathlib import Path, PurePath
-from typing import Dict, Tuple, Text, IO, Union, Iterable, Mapping
+from typing import IO, Dict, Iterable, Mapping, Tuple, Union
 from uuid import UUID
 
 import attr
@@ -22,11 +22,7 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
 
-from eodatasets3.model import (
-    DatasetDoc,
-    ODC_DATASET_SCHEMA_URL,
-    Eo3Dict,
-)
+from eodatasets3.model import ODC_DATASET_SCHEMA_URL, DatasetDoc, Eo3Dict
 from eodatasets3.properties import FileFormat
 
 
@@ -99,7 +95,7 @@ def _init_yaml() -> YAML:
 def dump_yaml(output_yaml: Path, *docs: Mapping) -> None:
     if not output_yaml.name.lower().endswith(".yaml"):
         raise ValueError(
-            "YAML filename doesn't end in *.yaml (?). Received {!r}".format(output_yaml)
+            f"YAML filename doesn't end in *.yaml (?). Received {output_yaml!r}"
         )
 
     yaml = _init_yaml()
@@ -121,7 +117,7 @@ def _yaml():
     return YAML(typ="safe")
 
 
-def loads_yaml(stream: Union[Text, IO]) -> Iterable[Dict]:
+def loads_yaml(stream: Union[str, IO]) -> Iterable[Dict]:
     """Dump yaml through a stream, using the default deserialisation settings."""
     return _yaml().load_all(stream)
 

--- a/eodatasets3/ui.py
+++ b/eodatasets3/ui.py
@@ -2,8 +2,7 @@ import os
 import urllib.parse
 from pathlib import Path
 from typing import Optional, Union
-from urllib.parse import urljoin
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import click
 

--- a/eodatasets3/utils.py
+++ b/eodatasets3/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Tuple, Dict, Any, Mapping
+from typing import Any, Dict, Iterable, Mapping, Tuple
 
 import ciso8601
 import click

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -12,15 +12,15 @@ from functools import partial
 from pathlib import Path
 from textwrap import indent
 from typing import (
-    List,
     Counter,
     Dict,
     Generator,
-    Optional,
-    Union,
-    Tuple,
-    Sequence,
     Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
 )
 from urllib.parse import urljoin, urlparse
 from urllib.request import urlopen
@@ -31,19 +31,19 @@ import click
 import numpy as np
 import rasterio
 from boltons.iterutils import get_path
-from click import style, echo, secho
+from click import echo, secho, style
+from datacube import Datacube
+from datacube.utils import InvalidDocException, changes, is_url, read_documents
+from datacube.utils.documents import load_documents
 from rasterio import DatasetReader
 from rasterio.crs import CRS
 from rasterio.errors import CRSError
 from shapely.validation import explain_validity
 
-from datacube import Datacube
-from datacube.utils import changes, read_documents, is_url, InvalidDocException
-from datacube.utils.documents import load_documents
-from eodatasets3 import serialise, model, utils
+from eodatasets3 import model, serialise, utils
 from eodatasets3.model import DatasetDoc
-from eodatasets3.ui import is_absolute, uri_resolve, bool_style
-from eodatasets3.utils import default_utc, EO3_SCHEMA
+from eodatasets3.ui import bool_style, is_absolute, uri_resolve
+from eodatasets3.utils import EO3_SCHEMA, default_utc
 
 
 class Level(enum.Enum):
@@ -265,7 +265,7 @@ def validate_dataset(
                     f"Product {product_name} expects a measurement {name!r})",
                 )
         measurements_not_in_product = set(dataset.measurements.keys()).difference(
-            set(m["name"] for m in product_definition.get("measurements") or ())
+            {m["name"] for m in product_definition.get("measurements") or ()}
         )
         if (not expect_extra_measurements) and measurements_not_in_product:
             things = ", ".join(sorted(measurements_not_in_product))

--- a/eodatasets3/verify.py
+++ b/eodatasets3/verify.py
@@ -1,12 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import
-
 import binascii
 import hashlib
 import logging
-
 import typing
-
 from distutils import spawn
 from pathlib import Path
 
@@ -80,7 +75,7 @@ def calculate_file_crc32(filename, block_size=1024 * 16):
     return f"{m & 0xFFFFFFFF:08x}"
 
 
-class PackageChecksum(object):
+class PackageChecksum:
     """
     Incrementally build a checksum file for a package.
 
@@ -137,7 +132,7 @@ class PackageChecksum(object):
         with output_file.open("wb") as f:
             f.writelines(
                 (
-                    "{0}\t{1}\n".format(
+                    "{}\t{}\n".format(
                         str(hash_), str(filename.relative_to(output_file.parent))
                     ).encode("utf-8")
                     for filename, hash_ in sorted(self._file_hashes.items())

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -9,23 +9,23 @@ import contextlib
 import os
 import re
 import sys
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
-from typing import List, Sequence, Optional, Iterable, Any, Tuple, Dict
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 import attr
 import numpy
 import rasterio
 from affine import Affine
-from boltons.iterutils import get_path, PathAccessError
+from boltons.iterutils import PathAccessError, get_path
 from click import secho
 from rasterio import DatasetReader
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 
-from eodatasets3 import serialise, utils, images, DatasetAssembler
+from eodatasets3 import DatasetAssembler, images, serialise, utils
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
 from eodatasets3.properties import Eo3Interface
@@ -91,9 +91,7 @@ def _unpack_products(
 
     for product in product_list:
         with sub_product(product, p):
-            for pathname in [
-                p for p in img_paths if "/{}/".format(product.upper()) in p
-            ]:
+            for pathname in [p for p in img_paths if f"/{product.upper()}/" in p]:
 
                 with do(f"Path {pathname!r}"):
                     dataset = h5group[pathname]
@@ -751,11 +749,11 @@ def find_a_granule_name(wagl_hdf5: Path) -> str:
 
 def _read_wagl_metadata(granule_group: h5py.Group):
     try:
-        wagl_path, *ancil_paths = [
+        wagl_path, *ancil_paths = (
             pth
             for pth in (_find_h5_paths(granule_group, "SCALAR"))
             if "METADATA" in pth
-        ]
+        )
     except ValueError:
         raise ValueError("No nbar metadata found in granule")
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-# coding=utf-8
 
 import pathlib
 from itertools import chain
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 import versioneer
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import
-
 import atexit
 import os
 import pathlib
@@ -34,14 +31,14 @@ def assert_same(o1, o2, prefix=""):
             _compare(i, val, o2[i])
     elif isinstance(o1, dict) and isinstance(o2, dict):
         for k, val in o1.items():
-            assert k in o2, "%s[%r] is missing.\n\t%r\n\t%r" % (prefix, k, o1, o2)
+            assert k in o2, f"{prefix}[{k!r}] is missing.\n\t{o1!r}\n\t{o2!r}"
         for k, val in o2.items():
-            assert k in o1, "%s[%r] is missing.\n\t%r\n\t%r" % (prefix, k, o2, o1)
+            assert k in o1, f"{prefix}[{k!r}] is missing.\n\t{o2!r}\n\t{o1!r}"
             _compare(k, val, o1[k])
     elif o1 != o2:
         sys.stderr.write("%r\n" % o1)
         sys.stderr.write("%r\n" % o2)
-        raise AssertionError("Mismatch for property %r:  %r != %r" % (prefix, o1, o2))
+        raise AssertionError(f"Mismatch for property {prefix!r}:  {o1!r} != {o2!r}")
 
 
 def assert_file_structure(folder, expected_structure, root=""):
@@ -53,12 +50,12 @@ def assert_file_structure(folder, expected_structure, root=""):
     :type expected_structure: dict[str,str|dict]
     """
     __tracebackhide__ = True
-    required_filenames = set(
+    required_filenames = {
         name for name, option in expected_structure.items() if option != "optional"
-    )
-    optional_filenames = set(
+    }
+    optional_filenames = {
         name for name, option in expected_structure.items() if option == "optional"
-    )
+    }
     assert (
         folder.exists()
     ), f"Expected base folder doesn't even exist! {folder.as_posix()!r}"
@@ -71,11 +68,11 @@ def assert_file_structure(folder, expected_structure, root=""):
         extra_files = actual_filenames - required_filenames
         added_text = "Extra  : %r" % (sorted(list(extra_files)))
         raise AssertionError(
-            "Folder mismatch of %r\n\t%s\n\t%s" % (root, missing_text, added_text)
+            f"Folder mismatch of {root!r}\n\t{missing_text}\n\t{added_text}"
         )
 
     for k, v in expected_structure.items():
-        id_ = "%s/%s" % (root, k) if root else k
+        id_ = f"{root}/{k}" if root else k
 
         is_optional = v == "optional"
 
@@ -85,12 +82,12 @@ def assert_file_structure(folder, expected_structure, root=""):
             if is_optional:
                 continue
 
-            assert False, "%s is missing" % (id_,)
+            assert False, f"{id_} is missing"
         elif isinstance(v, dict):
-            assert f.is_dir(), "%s is not a dir" % (id_,)
+            assert f.is_dir(), f"{id_} is not a dir"
             assert_file_structure(f, v, id_)
         elif isinstance(v, str):
-            assert f.is_file(), "%s is not a file" % (id_,)
+            assert f.is_file(), f"{id_} is not a file"
         else:
             assert (
                 False

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ from deepdiff.model import DiffLevel
 from ruamel import yaml
 from shapely.geometry.base import BaseGeometry
 
-from eodatasets3 import serialise, DatasetDoc
+from eodatasets3 import DatasetDoc, serialise
 
 
 def check_prepare_outputs(

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,17 +1,16 @@
-# coding=utf-8
 """
 Module
 """
-from __future__ import absolute_import
 
 import binascii
 import hashlib
-import rasterio
 import tempfile
 from pathlib import Path
-from rasterio import DatasetReader
 from typing import Dict, Tuple
+
 import numpy
+import rasterio
+from rasterio import DatasetReader
 
 allow_anything = object()
 
@@ -70,7 +69,7 @@ def directory_size(directory):
     return sum(p.stat().st_size for p in directory.rglob("*") if p.is_file())
 
 
-class FakeAncilFile(object):
+class FakeAncilFile:
     def __init__(self, base_folder, type_, filename, folder_offset=()):
         """
         :type base_folder: pathlib.Path

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,9 @@
+import json
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Callable
+from typing import Callable, Dict
 
-import json
 import pytest
 
 from eodatasets3 import serialise

--- a/tests/integration/h5downsample.py
+++ b/tests/integration/h5downsample.py
@@ -13,8 +13,7 @@ from typing import List, Optional
 
 import click
 import h5py
-from click import secho
-from click import style
+from click import secho, style
 
 from eodatasets3.ui import PathPath
 from eodatasets3.wagl import find_a_granule_name
@@ -45,7 +44,7 @@ RES_GROUP_PATH = re.compile(r"(.*/RES-GROUP-\d+)/")
 @click.option("--anti-alias/--no-anti-alias", is_flag=True, default=False)
 def downsample(input: Path, factor: int, anti_alias: bool):
     # Fail early if h5repack cli command is not available.
-    from sh import h5repack, gdal_translate
+    from sh import gdal_translate, h5repack
 
     granule_name = find_a_granule_name(input)
     fmask_image = input.with_name(f"{granule_name}.fmask.img")

--- a/tests/integration/prepare/test_esri_land_cover.py
+++ b/tests/integration/prepare/test_esri_land_cover.py
@@ -8,6 +8,7 @@ from shapely.geometry import shape
 from eodatasets3 import DatasetDoc, Eo3Dict
 from eodatasets3.model import GridDoc, MeasurementDoc, ProductDoc
 from eodatasets3.prepare.esri_land_cover_prepare import as_eo3
+
 from tests.common import assert_expected_eo3
 
 ESRI_ANTIMERIDIAN_OVERLAP_TIF: Path = (

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -3,10 +3,11 @@ from functools import partial
 from pathlib import Path
 from pprint import pformat
 
-from eodatasets3 import serialise
 from deepdiff import DeepDiff
 
+from eodatasets3 import serialise
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare
+
 from tests.common import run_prepare_cli
 
 NCEP_PR_WTR_FILE: Path = (

--- a/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from eodatasets3.prepare import sentinel_l1c_prepare
+
 from tests.common import check_prepare_outputs
 
 DATASET_PATH: Path = Path(__file__).parent.parent / (

--- a/tests/integration/prepare/test_prepare_landsat_l1.py
+++ b/tests/integration/prepare/test_prepare_landsat_l1.py
@@ -1,13 +1,13 @@
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Callable
+from typing import Callable, Dict
 
 import pytest
 
 from eodatasets3.prepare import landsat_l1_prepare
-from tests.common import check_prepare_outputs
-from tests.common import run_prepare_cli
+
+from tests.common import check_prepare_outputs, run_prepare_cli
 
 LC08_L2_C2_POST_20210507_INPUT_PATH: Path = (
     Path(__file__).parent.parent / "data" / "LC08_L2SP_098084_20210503_20210508_02_T1"

--- a/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from eodatasets3.prepare import sentinel_l1c_prepare
+
 from tests.common import check_prepare_outputs
 
 DATASET_DIR: Path = Path(__file__).parent.parent / (

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -14,14 +14,12 @@ import numpy
 import pytest
 from ruamel import yaml
 
-from eodatasets3 import DatasetAssembler, namer, DatasetPrepare, serialise
+from eodatasets3 import DatasetAssembler, DatasetPrepare, namer, serialise
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
+
 from tests import assert_file_structure
-from tests.common import (
-    assert_expected_eo3_path,
-    assert_same,
-)
+from tests.common import assert_expected_eo3_path, assert_same
 
 
 def test_dea_style_package(

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -8,6 +8,7 @@ import pytest
 from ruamel import yaml
 
 from eodatasets3 import DatasetAssembler, DatasetDoc, namer
+
 from tests.common import assert_expected_eo3_path
 
 

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -14,9 +14,10 @@ from rio_cogeo import cogeo
 
 import eodatasets3
 from eodatasets3.model import DatasetDoc
-from tests import assert_file_structure
-from tests.common import assert_same_as_file, assert_expected_eo3_path
+
 from . import assert_image
+from tests import assert_file_structure
+from tests.common import assert_expected_eo3_path, assert_same_as_file
 
 h5py = pytest.importorskip(
     "h5py",
@@ -118,11 +119,11 @@ def test_whole_landsat_wagl_package(
 
     # Checksum should include all files other than itself.
     [checksum_file] = expected_folder.rglob("*.sha1")
-    all_output_files = set(
+    all_output_files = {
         p.relative_to(checksum_file.parent)
         for p in expected_folder.rglob("*")
         if p != checksum_file
-    )
+    }
     files_in_checksum = {
         Path(line.split("\t")[1]) for line in checksum_file.read_text().splitlines()
     }
@@ -761,11 +762,11 @@ def test_esa_sentinel_wagl_package(tmp_path: Path):
 
     # Checksum should include all files other than itself.
     [checksum_file] = expected_folder.rglob("*.sha1")
-    all_output_files = set(
+    all_output_files = {
         p.relative_to(checksum_file.parent)
         for p in expected_folder.rglob("*")
         if p != checksum_file and not p.is_dir()
-    )
+    }
     files_in_checksum = {
         Path(line.split("\t")[1]) for line in checksum_file.read_text().splitlines()
     }

--- a/tests/integration/test_recompress.py
+++ b/tests/integration/test_recompress.py
@@ -1,10 +1,11 @@
 import shutil
 import tarfile
 from pathlib import Path
-from typing import List, Dict, Tuple
+from typing import Dict, List, Tuple
 
 import pytest
 from click.testing import CliRunner, Result
+
 from eodatasets3 import verify
 from eodatasets3.scripts import recompress
 
@@ -57,9 +58,9 @@ def test_recompress_dataset(base_in_path: Path, in_offset: str, tmp_path: Path):
     )
 
     # Pytest has better error messages for strings than Paths.
-    all_output_files = set(
+    all_output_files = {
         str(p.relative_to(output_base)) for p in output_base.rglob("*") if p.is_file()
-    )
+    }
 
     assert len(all_output_files) == 1, (
         f"Expected one output tar file. Got: {len(all_output_files)}"

--- a/tests/integration/test_serialise.py
+++ b/tests/integration/test_serialise.py
@@ -5,6 +5,7 @@ import ciso8601
 
 from eodatasets3 import serialise
 from eodatasets3.utils import default_utc
+
 from tests.common import dump_roundtrip
 
 

--- a/tests/integration/test_thumbnail.py
+++ b/tests/integration/test_thumbnail.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+
 import rasterio
 
 from eodatasets3.images import FileWrite, GridSpec

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -3,9 +3,11 @@ import shutil
 from pathlib import Path
 
 import pytest
+
 from eodatasets3 import serialise
 from eodatasets3.scripts import tostac
-from tests.common import run_prepare_cli, assert_same
+
+from tests.common import assert_same, run_prepare_cli
 
 TO_STAC_DATA: Path = Path(__file__).parent.joinpath("data/tostac")
 ODC_METADATA_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -1,7 +1,7 @@
 import operator
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, Union, Mapping, Sequence, Optional, Tuple
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pytest
@@ -13,7 +13,7 @@ from eodatasets3 import serialise, validate
 from eodatasets3.model import DatasetDoc
 
 # Either a dict or a path to a document
-from eodatasets3.validate import DocKind, guess_kind_from_contents, filename_doc_kind
+from eodatasets3.validate import DocKind, filename_doc_kind, guess_kind_from_contents
 
 Doc = Union[Dict, Path]
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,10 +1,9 @@
-# coding=utf-8
 """
 Module
 """
-from __future__ import absolute_import
 
-from eodatasets3.documents import find_metadata_path, _find_any_metadata_suffix
+from eodatasets3.documents import _find_any_metadata_suffix, find_metadata_path
+
 from tests import write_files
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -4,12 +4,10 @@ from contextlib import contextmanager
 
 import pytest
 
-from eodatasets3 import namer, Eo3Dict
+from eodatasets3 import Eo3Dict, namer
 from eodatasets3.model import DatasetDoc
 from eodatasets3.names import NamingConventions
-from eodatasets3.properties import (
-    PropertyOverrideWarning,
-)
+from eodatasets3.properties import PropertyOverrideWarning
 
 
 def test_multi_platform_fields():

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,10 +1,8 @@
-# coding=utf-8
-from __future__ import absolute_import
-
 import hashlib
 import unittest
 
 from eodatasets3 import verify
+
 from tests import write_files
 
 

--- a/tests/utils/subset_noaa_c_c_prwtreatm_1
+++ b/tests/utils/subset_noaa_c_c_prwtreatm_1
@@ -17,12 +17,13 @@ def _get_dimension_size(dim):
     return dim.size
 
 
-def create_test_file(infile, outfile, time_subset=2, netcdf_fmt='NETCDF4_CLASSIC'):
+def create_test_file(infile, outfile, time_subset=2, netcdf_fmt="NETCDF4_CLASSIC"):
     """
     Creates a subset of the water vapour dataset
     """
-    with Dataset(infile, 'r', netcdf_fmt) as rootin, \
-            Dataset(outfile, 'w', netcdf_fmt) as rootout:
+    with Dataset(infile, "r", netcdf_fmt) as rootin, Dataset(
+        outfile, "w", netcdf_fmt
+    ) as rootout:
 
         # Create dimensions
         for dim_name, dim in rootin.dimensions.items():
@@ -39,13 +40,13 @@ def create_test_file(infile, outfile, time_subset=2, netcdf_fmt='NETCDF4_CLASSIC
                 varname=var_name,
                 datatype=_var.datatype,
                 dimensions=_var.dimensions,
-                endian=_var.endian()
+                endian=_var.endian(),
             )
 
             for attr_name in _var.ncattrs():
                 var.setncattr(attr_name, _var.getncattr(attr_name))
 
-            if var_name in ['lat', 'lon']:
+            if var_name in ["lat", "lon"]:
                 var[:] = _var[:]
             else:
                 var[:] = _var[:time_subset]
@@ -54,14 +55,20 @@ def create_test_file(infile, outfile, time_subset=2, netcdf_fmt='NETCDF4_CLASSIC
 @click.command(
     help="""Creates a subset of a ncep/ncar reanalysis 1 water vapour file for testing"""
 )
-@click.option('--infile', type=click.Path(exists=True, dir_okay=False, readable=True),
-              help='Path to source pr_wtr.eatm.{year}.nc source file')
-@click.option('--outfile', type=click.Path(exists=False, dir_okay=False, writable=True),
-              help='Destination to write the data subset to')
+@click.option(
+    "--infile",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to source pr_wtr.eatm.{year}.nc source file",
+)
+@click.option(
+    "--outfile",
+    type=click.Path(exists=False, dir_okay=False, writable=True),
+    help="Destination to write the data subset to",
+)
 def cli(infile, outfile):
-    """ CLI wrapper for subset creation """
+    """CLI wrapper for subset creation"""
     create_test_file(infile, outfile)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()  # pylint: disable=E1120

--- a/versioneer.py
+++ b/versioneer.py
@@ -275,12 +275,12 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
 
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+
 import errno
 import json
 import os
@@ -344,7 +344,7 @@ def get_config_from_root(root):
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
+    with open(setup_cfg) as f:
         parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
@@ -404,7 +404,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
                 stderr=(subprocess.PIPE if hide_stderr else None),
             )
             break
-        except EnvironmentError:
+        except OSError:
             e = sys.exc_info()[1]
             if e.errno == errno.ENOENT:
                 continue
@@ -414,7 +414,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -429,7 +429,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
 
 LONG_VERSION_PY[
     "git"
-] = '''
+] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -961,7 +961,7 @@ def git_get_keywords(versionfile_abs):
     # _version.py.
     keywords = {}
     try:
-        f = open(versionfile_abs, "r")
+        f = open(versionfile_abs)
         for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
@@ -976,7 +976,7 @@ def git_get_keywords(versionfile_abs):
                 if mo:
                     keywords["date"] = mo.group(1)
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     return keywords
 
@@ -1000,11 +1000,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG) :] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1013,7 +1013,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r"\d", r)])
+        tags = {r for r in refs if re.search(r"\d", r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1116,7 +1116,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+            pieces["error"] = "tag '{}' doesn't start with prefix '{}'".format(
                 full_tag,
                 tag_prefix,
             )
@@ -1166,13 +1166,13 @@ def do_vcs_install(manifest_in, versionfile_source, ipy):
     files.append(versioneer_file)
     present = False
     try:
-        f = open(".gitattributes", "r")
+        f = open(".gitattributes")
         for line in f.readlines():
             if line.strip().startswith(versionfile_source):
                 if "export-subst" in line.strip().split()[1:]:
                     present = True
         f.close()
-    except EnvironmentError:
+    except OSError:
         pass
     if not present:
         f = open(".gitattributes", "a+")
@@ -1236,7 +1236,7 @@ def versions_from_file(filename):
     try:
         with open(filename) as f:
             contents = f.read()
-    except EnvironmentError:
+    except OSError:
         raise NotThisMethod("unable to read _version.py")
     mo = re.search(
         r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
@@ -1257,7 +1257,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print("set {} to '{}'".format(filename, versions["version"]))
 
 
 def plus_or_dot(pieces):
@@ -1482,7 +1482,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print(f"got version from file {versionfile_abs} {ver}")
         return ver
     except NotThisMethod:
         pass
@@ -1755,11 +1755,7 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (
-        EnvironmentError,
-        configparser.NoSectionError,
-        configparser.NoOptionError,
-    ) as e:
+    except (OSError, configparser.NoSectionError, configparser.NoOptionError) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
             print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
@@ -1784,9 +1780,9 @@ def do_setup():
     ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
-            with open(ipy, "r") as f:
+            with open(ipy) as f:
                 old = f.read()
-        except EnvironmentError:
+        except OSError:
             old = ""
         if INIT_PY_SNIPPET not in old:
             print(" appending to %s" % ipy)
@@ -1805,12 +1801,12 @@ def do_setup():
     manifest_in = os.path.join(root, "MANIFEST.in")
     simple_includes = set()
     try:
-        with open(manifest_in, "r") as f:
+        with open(manifest_in) as f:
             for line in f:
                 if line.startswith("include "):
                     for include in line.split()[1:]:
                         simple_includes.add(include)
-    except EnvironmentError:
+    except OSError:
         pass
     # That doesn't cover everything MANIFEST.in can do
     # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
@@ -1844,7 +1840,7 @@ def scan_setup_py():
     found = set()
     setters = False
     errors = 0
-    with open("setup.py", "r") as f:
+    with open("setup.py") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")


### PR DESCRIPTION
It rolls all the common tools into one: [black+isort+autoflake8+pyupgrade](https://github.com/Zac-HD/shed#shed).

Unlike our current setup, it also includes auto-fixes for many lint errors (eg. flake8), which is less of a hassle for newcomers.