### PR TITLE
Fix support for gridless stac conversions

### DIFF
--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 from pathlib import Path
+from typing import Dict
 
 import pytest
 
@@ -11,28 +12,80 @@ from tests.common import assert_same, run_prepare_cli
 
 TO_STAC_DATA: Path = Path(__file__).parent.joinpath("data/tostac")
 ODC_METADATA_FILE: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
-STAC_TEMPLATE_FILE: str = "ga_ls_ard_3_stac_item.json"
 STAC_EXPECTED_FILE: str = (
     "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json"
 )
 
 
-def test_tostac(input_doc_folder: Path):
-    input_metadata_path = input_doc_folder.joinpath(ODC_METADATA_FILE)
-    assert input_metadata_path.exists()
+@pytest.fixture
+def odc_dataset_path(input_doc_folder: Path):
+    d = input_doc_folder.joinpath(ODC_METADATA_FILE)
+    assert d.exists()
+    return d
 
-    run_tostac(input_metadata_path)
 
-    name = input_metadata_path.stem.replace(".odc-metadata", "")
-    actual_stac_path = input_metadata_path.with_name(f"{name}.stac-item.json")
-    assert actual_stac_path.exists()
+@pytest.fixture
+def expected_stac_doc(input_doc_folder: Path) -> Dict:
+    d = input_doc_folder.joinpath(STAC_EXPECTED_FILE)
+    assert d.exists()
+    return json.load(d.open())
 
-    expected_stac_path = input_doc_folder.joinpath(STAC_EXPECTED_FILE)
-    assert expected_stac_path.exists()
 
-    actual_doc = json.load(actual_stac_path.open())
-    expected_doc = json.load(expected_stac_path.open())
-    assert_same(expected_doc, actual_doc)
+def test_tostac(odc_dataset_path: Path, expected_stac_doc: Dict):
+
+    run_tostac(odc_dataset_path)
+
+    expected_output_path = odc_dataset_path.with_name(
+        odc_dataset_path.name.replace(".odc-metadata.yaml", ".stac-item.json")
+    )
+
+    assert expected_output_path.exists()
+
+    output_doc = json.load(expected_output_path.open())
+
+    assert_same(expected_stac_doc, output_doc)
+
+
+def test_tostac_no_grids(odc_dataset_path: Path, expected_stac_doc: Dict):
+    """
+    Converted EO1 datasets don't have grid information. Make sure it still outputs
+    without falling over.
+    """
+
+    # Remove grids from the input....
+    dataset = serialise.from_path(odc_dataset_path)
+    dataset.grids = None
+    serialise.to_path(odc_dataset_path, dataset)
+
+    run_tostac(odc_dataset_path)
+    expected_output_path = odc_dataset_path.with_name(
+        odc_dataset_path.name.replace(".odc-metadata.yaml", ".stac-item.json")
+    )
+
+    # No longer expect proj  fields (they come from grids).
+    remove_stac_properties(
+        expected_stac_doc, ("proj:shape", "proj:transform", "proj:epsg")
+    )
+    # But we do still expect a global CRS.
+    expected_stac_doc["properties"]["proj:epsg"] = 32656
+
+    output_doc = json.load(expected_output_path.open())
+    assert_same(expected_stac_doc, output_doc)
+
+
+def remove_stac_properties(doc: Dict, remove_properties=()):
+    """
+    Remove the given fields from properties and assets.
+    """
+
+    def remove_proj(dict: Dict):
+        for key in list(dict.keys()):
+            if key in remove_properties:
+                del dict[key]
+
+    remove_proj(doc["properties"])
+    for name, asset in doc["assets"].items():
+        remove_proj(asset)
 
 
 def test_add_property(input_doc_folder: Path):


### PR DESCRIPTION
Fix Stac conversion of datasets that don't have shape+transform information (from #216).

(DEA's older EO1 datasets don't have this information)

This was caught by Explorer's stac-api tests after the recent eodatasets release. I've expanded the test cases here to match.