### PR TITLE
Fix dockerfile install of modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN if [ "$ENVIRONMENT" = "deployment" ] ; then\
 RUN pip freeze
 
 # Is it working?
-RUN eo3-validate --version
+RUN /usr/local/bin/eo3-validate --version
 
 ENTRYPOINT ["/bin/tini", "--"]
-CMD ["eo3-validate"]
+CMD ["/usr/local/bin/eo3-validate"]


### PR DESCRIPTION
Fix the docker build.

Newer versions of pip don't work with  `--editable` installs of  `pyproject.toml` projects.

This was fun to debug, as the install "succeeded" but quietly didn't work. Lucky we had a test in there.

(I think the base image updated their version of pip, which is why this only recently broke)