### PR TITLE
s2 clean-up + embedded locations

### DIFF
--- a/eodatasets3/scripts/prepare.py
+++ b/eodatasets3/scripts/prepare.py
@@ -3,7 +3,7 @@ import click
 from ..prepare.landsat_l1_prepare import main as landsat_l1
 from ..prepare.nasa_c_m_mcd43a1_6_prepare import main as mcd43a1
 from ..prepare.noaa_c_c_prwtreatm_1_prepare import main as prwtr
-from ..prepare.sentinel_l1_prepare import main as sentinel_l1c
+from ..prepare.sentinel_l1_prepare import main as sentinel_l1
 
 
 @click.group()
@@ -13,10 +13,12 @@ def run():
 
 
 run.add_command(landsat_l1, name="landsat-l1")
-run.add_command(sentinel_l1c, name="sentinel-l1")
+run.add_command(sentinel_l1, name="sentinel-l1")
 run.add_command(mcd43a1, name="modis-mcd43a1")
 run.add_command(prwtr, name="noaa-prwtr")
 
+
+run.add_command(sentinel_l1, name="sentinel-l1c")
 
 if __name__ == "__main__":
     run()

--- a/eodatasets3/scripts/prepare.py
+++ b/eodatasets3/scripts/prepare.py
@@ -3,7 +3,7 @@ import click
 from ..prepare.landsat_l1_prepare import main as landsat_l1
 from ..prepare.nasa_c_m_mcd43a1_6_prepare import main as mcd43a1
 from ..prepare.noaa_c_c_prwtreatm_1_prepare import main as prwtr
-from ..prepare.sentinel_l1c_prepare import main as sentinel_l1c
+from ..prepare.sentinel_l1_prepare import main as sentinel_l1c
 
 
 @click.group()

--- a/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_esa_sentinel_l1.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from eodatasets3.prepare import sentinel_l1c_prepare
+from eodatasets3.prepare import sentinel_l1_prepare
 
 from tests.common import check_prepare_outputs
 
@@ -192,7 +192,7 @@ def test_run(tmp_path, expected_dataset_document):
         "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.odc-metadata.yaml"
     )
     check_prepare_outputs(
-        invoke_script=sentinel_l1c_prepare.main,
+        invoke_script=sentinel_l1_prepare.main,
         run_args=[
             tmp_path / DATASET_PATH.name,
         ],

--- a/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sinergise_sentinel_l1.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from eodatasets3.prepare import sentinel_l1c_prepare
+from eodatasets3.prepare import sentinel_l1_prepare
 
 from tests.common import check_prepare_outputs
 
@@ -153,7 +153,7 @@ def test_sinergise_sentinel_l1(tmp_path, expected_dataset_document):
         / "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.odc-metadata.yaml"
     )
     check_prepare_outputs(
-        invoke_script=sentinel_l1c_prepare.main,
+        invoke_script=sentinel_l1_prepare.main,
         run_args=[
             work_dir,
         ],


### PR DESCRIPTION
For s2 preparation:

- Add a `--provider` option, to only scan for the given provider's type of packages.
- Add an `--embed-location` option, for when users want to place the metadata in a different location to the data
- Rename `sentinel-l1c` to `sentinel-l1` for consistency with other commands.
