### PR TITLE
Add pystac-native conversion

### DIFF
--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -18,7 +18,6 @@ from pystac.extensions.eo import Band, EOExtension
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.view import ViewExtension
 from pystac.utils import datetime_to_str
-from requests_cache import CachedSession
 
 from eodatasets3.model import DatasetDoc, GridDoc
 
@@ -385,26 +384,12 @@ def validate_item(
     :param item_doc:
     :param allow_cached_specs: Allow using a cached spec.
                               Disable to force-download the spec again.
-    :param disallow_network_access: Only allow validation using cached specs.
-    :param log: Callback for human-readable progress/status (eg: 'print').
-    :param schema_host: The host to download stac schemas from.
 
     :raises NoAvailableSchemaError: When cannot find a spec for the given Stac version+extentions
     """
-
-    one_day = 60 * 60 * 24
-
-    with CachedSession(
-        "stac_schema_cache",
-        backend="sqlite",
-        expire_after=one_day,
-        old_data_on_error=True,
-    ) as session:
-        if not allow_cached_specs:
-            session.cache.clear()
-
-        item = Item.from_dict(item_doc)
-        item.validate()
+    # Pystac now does this for us, but we'll keep this method for backwards compat.
+    item = Item.from_dict(item_doc)
+    item.validate()
 
 
 def _uri_resolve(location: str, path: str):

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 import datacube.utils.uris as dc_uris
+import pystac
 from datacube.utils.geometry import CRS, Geometry
 from pystac import Asset, Item, Link, MediaType
 from pystac.errors import STACError
@@ -206,14 +207,14 @@ def eo3_to_stac_properties(
     return properties
 
 
-def to_stac_item(
+def to_pystac_item(
     dataset: DatasetDoc,
     stac_item_destination_url: str,
     dataset_location: Optional[str] = None,
     odc_dataset_metadata_url: Optional[str] = None,
     explorer_base_url: Optional[str] = None,
     collection_url: Optional[str] = None,
-) -> dict:
+) -> pystac.Item:
     """
     Convert the given ODC Dataset into a Stac Item document.
 
@@ -345,7 +346,30 @@ def to_stac_item(
 
         item.add_asset(name, asset=asset)
 
-    return item.to_dict()
+    return item
+
+
+def to_stac_item(
+    dataset: DatasetDoc,
+    stac_item_destination_url: str,
+    dataset_location: Optional[str] = None,
+    odc_dataset_metadata_url: Optional[str] = None,
+    explorer_base_url: Optional[str] = None,
+    collection_url: Optional[str] = None,
+) -> dict:
+    """
+    Convert the given dataset to a stac item (as a dictionary).
+
+    See ``to_pystac_item()`` for the parameters.
+    """
+    return to_pystac_item(
+        dataset,
+        stac_item_destination_url,
+        dataset_location,
+        odc_dataset_metadata_url,
+        explorer_base_url,
+        collection_url,
+    ).to_dict()
 
 
 def validate_item(

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup(
         "shapely",
         "structlog",
         "xarray",
-        "requests-cache>=0.6",
         "datacube",
         "python-rapidjson",
         "pystac>=1.1.0",


### PR DESCRIPTION
Clients that use pystac themselves would rather receive pystac objects, not dicts.

(also: remove the unnecessary http caching. We no longer manually download schemas)