### PR TITLE
Per-field validation. and use embedded locations during measurement validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: tests/integration/data
 repos:
     # Normalise all Python code. (Black + isort + pyupgrade + autoflake)
     - repo: https://github.com/Zac-HD/shed
-      rev: 0.5.3
+      rev: 0.9.2
       hooks:
       - id: shed
     - repo: https://gitlab.com/pycqa/flake8
@@ -24,12 +24,12 @@ repos:
                   - pep8-naming # Follow pep8 naming rules (eg. function names lowercase)
     # Common Python security checks. (this is complementary to dlint in flake8)
     - repo: https://github.com/PyCQA/bandit
-      rev: '1.7.0'
+      rev: '1.7.4'
       hooks:
         - id: bandit
           exclude: '^tests/|_version.py|versioneer.py'
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.0.1
+      rev: v4.1.0
       hooks:
         - id: check-added-large-files # We don't want huge files. (Cut down test data!)
           args: ['--maxkb=2000']

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -304,6 +304,7 @@ def prepare_and_write(
     source_telemetry: Path = None,
     # TODO: Can we infer producer automatically? This is bound to cause mistakes othewise
     producer="usgs.gov",
+    embed_location: bool = False,
 ) -> Tuple[uuid.UUID, Path]:
     """
     Prepare an eo3 metadata file for a Level1 dataset.
@@ -490,7 +491,7 @@ def prepare_and_write(
                     expand_valid_data=False,
                 )
         p.note_accessory_file("metadata:landsat_mtl", Path(mtl_filename))
-        return p.done()
+        return p.done(embed_location=embed_location)
 
 
 @click.command(help=__doc__)
@@ -507,6 +508,12 @@ def prepare_and_write(
     "(either the folder or metadata file)",
     required=False,
     type=PathPath(exists=True),
+)
+@click.option(
+    "--embed-location/--no-embed-location",
+    is_flag=True,
+    help="Embed the location of the dataset in the metadata "
+    "(if you wish to store them separately)",
 )
 @click.option(
     "--producer",
@@ -534,6 +541,7 @@ def main(
     datasets: List[Path],
     overwrite_existing: bool,
     producer: str,
+    embed_location: bool,
     source_telemetry: Optional[Path],
     newer_than: datetime,
 ):
@@ -577,6 +585,7 @@ def main(
                 output_yaml,
                 producer=producer,
                 source_telemetry=source_telemetry,
+                embed_location=embed_location,
             )
             logging.info("Wrote dataset %s to %s", output_uuid, output_path)
 

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -329,8 +329,8 @@ def _rglob_with_self(path: Path, pattern: str) -> Iterable[Path]:
 @click.option(
     "--embed-location/--no-embed-location",
     is_flag=True,
-    default=None,
-    help="Overwrite if exists (otherwise skip)",
+    help="Embed the location of the dataset in the metadata "
+    "(if you wish to store them separately)",
 )
 @click.option(
     "--provider",

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -173,9 +173,9 @@ def _odc_links(
         warnings.warn("No collection provided for Stac Item.")
 
 
-def _get_projection(dataset: DatasetDoc) -> Tuple[int, str]:
+def _get_projection(dataset: DatasetDoc) -> Tuple[Optional[int], Optional[str]]:
     if dataset.crs is None:
-        return None
+        return None, None
 
     crs_l = dataset.crs.lower()
     epsg = None

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -275,12 +275,14 @@ def validate_dataset(
                 hint="This may be valid, as it's allowed by ODC. Set `expect_extra_measurements` to mute this.",
             )
 
+    dataset_location = dataset.locations[0] if dataset.locations else readable_location
+
     # If we have a location:
     # For each measurement, try to load it.
     # If loadable:
     if thorough:
         for name, measurement in dataset.measurements.items():
-            full_path = uri_resolve(readable_location, measurement.path)
+            full_path = uri_resolve(dataset_location, measurement.path)
             expected_measurement = required_measurements.get(name)
 
             band = measurement.band or 1

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -452,7 +452,6 @@ def test_odc_product_schema(
 def test_warn_bad_product_license(
     eo_validator: ValidateRunner, l1_ls8_metadata_path: Path, product: Dict
 ):
-
     # Missing license is a warning.
     del product["license"]
     eo_validator.assert_valid(product, expect_no_messages=False)
@@ -752,6 +751,30 @@ def test_dataset_is_not_a_product(example_metadata: Dict):
     """
     assert guess_kind_from_contents(example_metadata) == DocKind.dataset
     assert filename_doc_kind(Path("asdf.odc-metadata.yaml")) == DocKind.dataset
+
+
+def test_get_field_offsets(metadata_type: Dict):
+    """
+    Test the get_field_offsets function.
+    """
+    assert list(validate._get_field_offsets(metadata_type)) == [
+        ("id", [["id"]]),
+        ("sources", [["lineage", "source_datasets"]]),
+        ("grid_spatial", [["grid_spatial", "projection"]]),
+        ("measurements", [["measurements"]]),
+        ("creation_dt", [["properties", "odc:processing_datetime"]]),
+        ("label", [["label"]]),
+        ("format", [["properties", "odc:file_format"]]),
+        (
+            "time",
+            [
+                ["properties", "dtr:start_datetime"],
+                ["properties", "datetime"],
+                ["properties", "dtr:end_datetime"],
+                ["properties", "datetime"],
+            ],
+        ),
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
- During validation, check that all defined metadata fields exist in the dataset
- If a location is embedded in the dataset, it should be used when reading measurements. This more closely matches the behavior of ODC. 
    - (this fixes S2 L1 data validation, which requires reading data from `zip://` locations) 