### PR TITLE
Nicer field errors

### DIFF
--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -50,8 +50,6 @@ from eodatasets3.utils import EO3_SCHEMA, default_utc
 
 DEFAULT_NULLABLE_FIELDS = [
     "label",
-    # When missing, it's considered 'final'.
-    "dataset_maturity",
 ]
 
 


### PR DESCRIPTION
- Improve field error messages: say what type was expected
- ~Include dataset_maturity as an optional field~ (removed: fixed upstream in DEA config)
- Make optional fields a module-level var so they're expandable in a pinch