### PR TITLE
S2-L1-prepare should allow subfolder structures

### DIFF
--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -379,7 +379,7 @@ def main(
     )
     for i, input_path in enumerate(datasets):
         # The default input_relative path is a parent folder named 'L1C'.
-        if i == 0 and input_relative_to is None:
+        if output_base and (i == 0 and input_relative_to is None):
             for parent in input_path.parents:
                 if parent.name.lower() == "l1c":
                     input_relative_to = parent

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -177,7 +177,7 @@ def validate_dataset(
     nullable_fields: Iterable[str] = _default,
 ) -> ValidationMessages:
     """
-    Validate a a dataset document, optionally against the given product.
+    Validate a dataset document, optionally against the given product.
 
     By default this will only look at the metadata, run with thorough=True to
     open the data files too.


### PR DESCRIPTION
Allow an output path to mirror an input path structure automatically:

```
❯ eo3-prepare sentinel-l1 \
      ~/dea/test-data/L1C/2022/2022-03/25S125E-30S130E/S2B_MSIL1C_20210719T010729_N0301_R045_T53LQC_20210719T021248.zip \
      --output-base /out
2022-03-28 10:02:56,122 INFO Wrote dataset e9b8195a-e1aa-55f8-a66e-afc3eb39ee59
to /out/2022/2022-03/25S125E-30S130E/S2B_MSIL1C_20210719T010729_N0301_R045_T53LQC_20210719T021248.odc-metadata.yaml
```