### PR TITLE
Quality improvements to folder scanning, filtering, logging and reliability of s2 prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,67 @@ exotic formats: `pip install .[ancillary]`
 	  noaa-prwtr     Prepare NCEP/NCAR reanalysis 1 water pressure datasets...
 	  sentinel-l1   Prepare eo3 metadata for Sentinel-2 Level 1C data produced...
 
+Prep scripts have their own options, for example Sentinel L1 generation can filter by time
+or region, if the inputs follow a common directory structure:
+
+```
+❯ eo3-prepare sentinel-l1 --help
+Usage: eo3-prepare sentinel-l1 [OPTIONS] [DATASETS]...
+
+  Prepare eo3 metadata for Sentinel-2 Level 1C data produced by Sinergise or
+  esa.
+
+  Takes ESA zipped datasets or Sinergise dataset directories
+
+Options:
+  -v, --verbose
+  --overwrite-existing / --skip-existing
+                                  Overwrite if exists (otherwise skip)
+  --embed-location / --no-embed-location
+                                  Embed the location of the dataset in the
+                                  metadata? (if you wish to store them
+                                  separately. default: auto)
+  --provider [sinergise.com|esa.int]
+                                  Restrict scanning to only packages of the
+                                  given provider. (ESA assumes a zip file,
+                                  sinergise a directory)
+  --output-base DIRECTORY         Write metadata files into a directory
+                                  instead of alongside each dataset
+  --input-relative-to DIRECTORY   Input root folder that should be used for
+                                  the subfolder hierarchy in the output-base
+  --limit-regions-file FILE       A file containing the list of region codes
+                                  to limit the scan to
+  --after-month YEAR-MONTH        Limit the scan to datasets newer than a
+                                  given month (expressed as {year}-{month}, eg
+                                  '2010-01')
+  --before-month YEAR-MONTH       Limit the scan to datasets older than the
+                                  given month (expressed as {year}-{month}, eg
+                                  '2010-01')
+  --help                          Show this message and exit.
+```
+
+An example of preparing metadata in a separate directory (not alongside the datasets) at NCI
+can be as follows:
+
+```bash
+module use -a /g/data/v10/private/modules/modulefiles /g/data/v10/public/modules/modulefiles
+module load eodatasets3
+
+# With a full list of input paths, 4 workers, and separate output directory:
+eo3-prepare sentinel-l1 -j 4 --output-base my-metadata-directory
+   -f l1cs-2022-05-02.txt
+  /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2021
+
+# Filtered to a certain region list and recent months:
+eo3-prepare sentinel-l1 \
+    --output-base /g/data/v10/agdc/jez/c3/L1C  \
+    --limit-regions-file test-regions.txt \
+    --after-month 2022-04 \
+    -f l1cs-2022-05-02.txt
+
+```
+
+
 `eo3-package-wagl`: Convert and package WAGL HDF5 outputs.
 
  Needs the wagl dependencies group: `pip install .[wagl]`

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -1,5 +1,5 @@
 """
-Prepare eo3 metadata for Sentinel-2 Level 1C data produced by Sinergise or esa.
+Prepare eo3 metadata for Sentinel-2 Level 1C data produced by Sinergise or ESA.
 
 Takes ESA zipped datasets or Sinergise dataset directories
 """
@@ -342,7 +342,7 @@ class FolderInfo:
     # Compiled regexp for extracting year, month and region
     # Standard layout is of the form: 'L1C/{yyyy}/{yyyy}-{mm}/{area}/S2*_{region}_{timestamp}(.zip)'
     STANDARD_SUBFOLDER_LAYOUT = re.compile(
-        r"(\d{4})/(\d{4})-(\d{2})/[\dSE]+-[\dSE]+/S2[AB]_MSIL1C_[^/]+_T([A-Z\d]+)_[\dT]+(\.zip)?$"
+        r"(\d{4})/(\d{4})-(\d{2})/[\dNESW]+-[\dNESW]+/S2[AB]_MSIL1C_[^/]+_T([A-Z\d]+)_[\dT]+(\.zip)?$"
     )
 
     @classmethod

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -304,9 +304,16 @@ def _extract_esa_fields(dataset, p) -> Iterable[Path]:
         p.note_accessory_file("metadata:s2_tile", tile_md)
 
         user_product_md = one("MTD_MSIL1C.xml")
-        p.properties.update(
-            process_user_product_metadata(z.read(user_product_md).decode("utf-8"))
-        )
+        for prop, value in process_user_product_metadata(
+            z.read(user_product_md).decode("utf-8")
+        ).items():
+            if prop in p.properties:
+                _LOG.debug(
+                    f"Not overridding tile metadata {prop!r} with product metadata"
+                )
+            else:
+                p.properties[prop] = value
+
         p.note_accessory_file("metadata:s2_user_product", user_product_md)
 
         return [Path(p) for p in z.namelist() if "IMG_DATA" in p and p.endswith(".jp2")]

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -20,6 +20,7 @@ from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import attr
 import click
+from datacube.utils.uris import normalise_path
 from defusedxml import minidom
 
 from eodatasets3 import DatasetPrepare
@@ -398,7 +399,7 @@ class Job:
 @click.option("-v", "--verbose", is_flag=True)
 @click.argument(
     "datasets",
-    type=PathPath(exists=True, readable=True, writable=False, resolve_path=True),
+    type=PathPath(),
     nargs=-1,
 )
 @click.option(
@@ -520,6 +521,7 @@ def main(
         label="Scanning inputs",
     ) as progress:
         for i, input_path in enumerate(progress):
+            input_path = normalise_path(input_path)
             input_count += 1
 
             # Scan the input path for our key identifying files of a package.
@@ -607,7 +609,7 @@ def main(
                             continue
 
                 if output_base:
-                    output_folder = output_base.absolute()
+                    output_folder = normalise_path(output_base)
                     # If we want to copy the input folder hierarchy
                     if input_relative_to:
                         output_folder = output_folder / input_path.parent.relative_to(

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -13,10 +13,9 @@ import traceback
 import uuid
 import warnings
 import zipfile
-from itertools import chain
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
 
 import attr
 import click
@@ -487,7 +486,7 @@ class Job:
 def main(
     output_base: Optional[Path],
     input_relative_to: Optional[Path],
-    datasets: List[Path],
+    datasets: Tuple[Path],
     datasets_path: Optional[Path],
     provider: Optional[str],
     overwrite_existing: bool,
@@ -511,166 +510,168 @@ def main(
     if limit_regions_file:
         limit_regions = set(limit_regions_file.read_text().splitlines())
 
-    extra_datasets = datasets_path.read_text().splitlines() if datasets_path else []
+    if datasets_path:
+        datasets = [
+            *datasets,
+            *(Path(p.strip()) for p in (datasets_path.read_text().splitlines())),
+        ]
 
-    input_count = 0
-    jobs: List[Job] = []
-    with click.progressbar(
-        chain(datasets, (Path(p.strip()) for p in extra_datasets)),
-        length=len(datasets) + len(extra_datasets),
-        label="Scanning inputs",
-    ) as progress:
-        for i, input_path in enumerate(progress):
-            input_path = normalise_path(input_path)
-            input_count += 1
+    # The default input_relative path is a parent folder named 'L1C'.
+    if output_base and input_relative_to is None and datasets:
+        for parent in datasets[0].parents:
+            if parent.name.lower() == "l1c":
+                input_relative_to = parent
+                break
+        else:
+            raise ValueError(
+                "Unknown root folder for path subfolders. "
+                "(Hint: specify --input-relative-to with a parent folder of the inputs. "
+                "Outputs will use the same subfolder structure.)"
+            )
 
-            # Scan the input path for our key identifying files of a package.
-            in_out_paths = []
-            if provider == "sinergise.com" or not provider:
-                in_out_paths.extend(
-                    (
-                        "sinergise.com",
-                        # Dataset location is the metadata file itself.
-                        p,
-                        # Output is an inner metadata file, with the same name as the folder (usually S2A....).
-                        (p.parent / f"{p.parent.stem}.odc-metadata.yaml"),
+    _LOG.info(f"{len(datasets)} paths(s) to process. (using {workers} worker[s])")
+
+    def find_jobs() -> Iterable[Job]:
+        with click.progressbar(datasets, label="Preparing metadata") as progress:
+            for i, input_path in enumerate(progress):
+                input_path = normalise_path(input_path)
+
+                # Scan the input path for our key identifying files of a package.
+                in_out_paths = []
+                if provider == "sinergise.com" or not provider:
+                    in_out_paths.extend(
+                        (
+                            "sinergise.com",
+                            # Dataset location is the metadata file itself.
+                            p,
+                            # Output is an inner metadata file, with the same name as the folder (usually S2A....).
+                            (p.parent / f"{p.parent.stem}.odc-metadata.yaml"),
+                        )
+                        for p in _rglob_with_self(input_path, "tileInfo.json")
                     )
-                    for p in _rglob_with_self(input_path, "tileInfo.json")
-                )
-            if provider == "esa.int" or not provider:
-                in_out_paths.extend(
-                    (
-                        "esa.int",
-                        # Dataset location is the zip file
-                        p,
-                        # Metadata is a sibling file with a metadata suffix.
-                        p.with_suffix(".odc-metadata.yaml"),
+                if provider == "esa.int" or not provider:
+                    in_out_paths.extend(
+                        (
+                            "esa.int",
+                            # Dataset location is the zip file
+                            p,
+                            # Metadata is a sibling file with a metadata suffix.
+                            p.with_suffix(".odc-metadata.yaml"),
+                        )
+                        for p in _rglob_with_self(input_path, "*.zip")
                     )
-                    for p in _rglob_with_self(input_path, "*.zip")
-                )
 
-            if not in_out_paths:
-                raise ValueError(
-                    f"No S2 datasets found in given path {input_path}. "
-                    f"Expected either Sinergise (productInfo.json) files or ESA zip files to be contained in it."
-                )
-
-            # The default input_relative path is a parent folder named 'L1C'.
-            if output_base and (i == 0 and input_relative_to is None):
-                for parent in input_path.parents:
-                    if parent.name.lower() == "l1c":
-                        input_relative_to = parent
-                        break
-                else:
+                if not in_out_paths:
                     raise ValueError(
-                        "Unknown root folder for path subfolders. "
-                        "(Hint: specify --input-relative-to with a parent folder of the inputs. "
-                        "Outputs will use the same subfolder structure.)"
+                        f"No S2 datasets found in given path {input_path}. "
+                        f"Expected either Sinergise (productInfo.json) files or ESA zip files to be contained in it."
                     )
 
-            for producer, ds_path, output_yaml in in_out_paths:
+                for producer, ds_path, output_yaml in in_out_paths:
+                    # Filter based on metadata
+                    info = FolderInfo.for_path(ds_path)
 
-                # Filter based on metadata
-                info = FolderInfo.for_path(ds_path)
-
-                # Skip regions that are not in the limit?
-                if limit_regions or before_month or after_month:
-                    if info is None:
-                        raise ValueError(
-                            f"Cannot filter from non-standard folder layout: {input_path}"
-                        )
-
-                    if limit_regions:
-                        if info.region_code in limit_regions:
-                            _LOG.debug(
-                                f"Skipping because region {info.region_code!r} is in region filter"
+                    # Skip regions that are not in the limit?
+                    if limit_regions or before_month or after_month:
+                        if info is None:
+                            raise ValueError(
+                                f"Cannot filter from non-standard folder layout: {input_path}"
                             )
+
+                        if limit_regions:
+                            if info.region_code in limit_regions:
+                                _LOG.debug(
+                                    f"Skipping because region {info.region_code!r} is in region filter"
+                                )
+                                continue
+
+                        if after_month is not None:
+                            year, month = after_month
+
+                            if info.year < year or (
+                                info.year == year and info.month < month
+                            ):
+                                _LOG.debug(
+                                    f"Skipping because year {info.year}-{info.month} is older than {year}-{month}"
+                                )
+                                continue
+                        if before_month is not None:
+                            year, month = before_month
+
+                            if info.year > year or (
+                                info.year == year and info.month > month
+                            ):
+                                _LOG.debug(
+                                    f"Skipping because year {info.year}-{info.month} is newer than {year}-{month}"
+                                )
+                                continue
+
+                    if output_base:
+                        output_folder = normalise_path(output_base)
+                        # If we want to copy the input folder hierarchy
+                        if input_relative_to:
+                            output_folder = (
+                                output_folder
+                                / input_path.parent.relative_to(input_relative_to)
+                            )
+
+                        output_yaml = output_folder / output_yaml.name
+
+                    if output_yaml.exists():
+                        if not overwrite_existing:
+                            _LOG.debug("Output exists: skipping. %s", output_yaml)
                             continue
 
-                    if after_month is not None:
-                        year, month = after_month
+                        _LOG.debug("Output exists: overwriting %s", output_yaml)
 
-                        if info.year < year or (
-                            info.year == year and info.month < month
-                        ):
-                            _LOG.debug(
-                                f"Skipping because year {info.year}-{info.month} is older than {year}-{month}"
-                            )
-                            continue
-                    if before_month is not None:
-                        year, month = before_month
-
-                        if info.year > year or (
-                            info.year == year and info.month > month
-                        ):
-                            _LOG.debug(
-                                f"Skipping because year {info.year}-{info.month} is newer than {year}-{month}"
-                            )
-                            continue
-
-                if output_base:
-                    output_folder = normalise_path(output_base)
-                    # If we want to copy the input folder hierarchy
-                    if input_relative_to:
-                        output_folder = output_folder / input_path.parent.relative_to(
-                            input_relative_to
-                        )
-
-                    output_yaml = output_folder / output_yaml.name
-
-                if output_yaml.exists():
-                    if not overwrite_existing:
-                        _LOG.info("Output exists: skipping. %s", output_yaml)
-                        continue
-
-                    _LOG.info("Output exists: overwriting %s", output_yaml)
-
-                jobs.append(
-                    Job(ds_path, output_yaml, producer, embed_location=embed_location)
-                )
-
-    _LOG.info(
-        f"{len(jobs)} dataset(s) to process out of {input_count} inputs. (using {workers} worker[s])"
-    )
+                    yield Job(
+                        ds_path, output_yaml, producer, embed_location=embed_location
+                    )
 
     errors = 0
 
     if dry_run:
         _LOG.info("Dry run: not writing any files.")
-        sys.exit(0)
 
     # If only one process, call it directly.
     # (Multiprocessing makes debugging harder, so we prefer to make it optional)
-    if workers == 1:
-        with click.progressbar(jobs, label="Preparing metadata") as progress:
-            for job in progress:
-                try:
+    successes = 0
+    if workers == 1 or dry_run:
+        for job in find_jobs():
+            try:
+                if dry_run:
+                    _LOG.info(
+                        "Would write dataset %s to %s",
+                        job.dataset_path,
+                        job.output_yaml_path,
+                    )
+                else:
                     uuid_, path = prepare_and_write(
                         job.dataset_path,
                         job.output_yaml_path,
                         job.producer,
                         embed_location=job.embed_location,
                     )
-                    _LOG.info("Wrote dataset %s to %s", uuid_, path)
-                except Exception:
-                    _LOG.exception("Failed to write dataset: %s", job)
-                    errors += 1
+                    _LOG.debug("Wrote dataset %s to %s", uuid_, path)
+                successes += 1
+            except Exception:
+                _LOG.exception("Failed to write dataset: %s", job)
+                errors += 1
     else:
-        with click.progressbar(jobs, label="Preparing metadata") as progress:
-            with Pool(processes=workers) as pool:
-                for res in pool.imap_unordered(_write_dataset_safe, jobs):
-                    progress.update(1)
-                    if isinstance(res, str):
-                        _LOG.error(res)
-                        errors += 1
-                    else:
-                        uuid_, path = res
-                        _LOG.info("Wrote dataset %s to %s", uuid_, path)
-                pool.close()
-                pool.join()
+        with Pool(processes=workers) as pool:
+            for res in pool.imap_unordered(_write_dataset_safe, find_jobs()):
+                if isinstance(res, str):
+                    _LOG.error(res)
+                    errors += 1
+                else:
+                    uuid_, path = res
+                    _LOG.debug("Wrote dataset %s to %s", uuid_, path)
+                    successes += 1
+            pool.close()
+            pool.join()
 
-    _LOG.debug(
-        f"Completed {len(jobs)-errors} dataset(s) successfully, with {errors} failure(s)"
+    _LOG.info(
+        f"Completed {successes} dataset(s) successfully, with {errors} failure(s)"
     )
     sys.exit(errors)
 

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -343,7 +343,7 @@ class FolderInfo:
     # Standard layout is of the form: 'L1C/{yyyy}/{yyyy}-{mm}/{area}/S2*_{region}_{timestamp}(.zip)'
     STANDARD_SUBFOLDER_LAYOUT = re.compile(
         r"(\d{4})/(\d{4})-(\d{2})/[\dNESW]+-[\dNESW]+/"
-        r"S2[AB](?:_OPER_PRD)?_MSIL1C(?:_PDMC)?(?:_[a-zA-Z0-9]+){3}(?:_T([A-Z\d]+))?_[\dT]+(\.zip)?$"
+        r"S2[AB](?:_OPER_PRD)?_MSIL1C(?:_PDMC)?(?:_[a-zA-Z0-9]+){3}(?:_T([A-Z\d]+))?_[\dT]+(\.zip|/tileInfo\.json)?$"
     )
 
     @classmethod
@@ -575,7 +575,7 @@ def main(
                     if limit_regions or before_month or after_month:
                         if info is None:
                             raise ValueError(
-                                f"Cannot filter from non-standard folder layout: {input_path}"
+                                f"Cannot filter from non-standard folder layout: {ds_path}"
                             )
 
                         if limit_regions:

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -337,12 +337,13 @@ class FolderInfo:
 
     year: int
     month: int
-    region_code: str
+    region_code: Optional[str]
 
     # Compiled regexp for extracting year, month and region
     # Standard layout is of the form: 'L1C/{yyyy}/{yyyy}-{mm}/{area}/S2*_{region}_{timestamp}(.zip)'
     STANDARD_SUBFOLDER_LAYOUT = re.compile(
-        r"(\d{4})/(\d{4})-(\d{2})/[\dNESW]+-[\dNESW]+/S2[AB]_MSIL1C_[^/]+_T([A-Z\d]+)_[\dT]+(\.zip)?$"
+        r"(\d{4})/(\d{4})-(\d{2})/[\dNESW]+-[\dNESW]+/"
+        r"S2[AB](?:_OPER_PRD)?_MSIL1C(?:_PDMC)?(?:_[a-zA-Z0-9]+){3}(?:_T([A-Z\d]+))?_[\dT]+(\.zip)?$"
     )
 
     @classmethod
@@ -460,7 +461,8 @@ class Job:
 )
 @click.option(
     "--limit-regions-file",
-    help="A file containing the list of region codes to limit the scan to",
+    help="A file containing the list of region codes to limit the scan to. "
+    "(Note that some older ESA datasets have no region code, and will not match any region here.)",
     required=False,
     type=PathPath(
         exists=True, readable=True, dir_okay=False, file_okay=True, resolve_path=True

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -37,6 +37,16 @@ def test_subfolder_info_extraction():
     )
     assert info == FolderInfo(2021, 7, "47QMB")
 
+    # Older dataset structure had no region code
+    info = FolderInfo.for_path(
+        Path(
+            "/g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2015/2015-12/30S170E-35S175E/"
+            "S2A_OPER_PRD_MSIL1C_PDMC_20151225T022834_R072_V20151224T223838_20151224T223838.zip"
+        )
+    )
+    assert info == FolderInfo(2015, 12, None)
+    #
+
     # A folder that doesn't follow standard layout will return no info
     info = FolderInfo.for_path(
         Path(

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -29,6 +29,14 @@ def test_subfolder_info_extraction():
     )
     assert info == FolderInfo(2022, 3, "53LQC")
 
+    info = FolderInfo.for_path(
+        Path(
+            "/g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2021/2021-07/20N095E-15N100E/"
+            "S2B_MSIL1C_20210716T035539_N0301_R004_T47QMB_20210716T063913.zip"
+        )
+    )
+    assert info == FolderInfo(2021, 7, "47QMB")
+
     # A folder that doesn't follow standard layout will return no info
     info = FolderInfo.for_path(
         Path(

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -45,7 +45,15 @@ def test_subfolder_info_extraction():
         )
     )
     assert info == FolderInfo(2015, 12, None)
-    #
+
+    # A sinergise-like input path.
+    info = FolderInfo.for_path(
+        Path(
+            "/test_filter_folder_structure_i1/L1C/2019/2019-01/25S125E-30S130/"
+            "S2B_MSIL1C_20190111T000249_N0209_R030_T55HFA_20190111T011446/tileInfo.json"
+        )
+    )
+    assert info == FolderInfo(2019, 1, "55HFA")
 
     # A folder that doesn't follow standard layout will return no info
     info = FolderInfo.for_path(


### PR DESCRIPTION
Some minor quality improvements from running it at NCI, and from writing a few docs.

- Improved folder scanning (many fs operations are very slow at on NCI's large filesystems)
- Show interactive progress when running, and improve logging output when run from a non-terminal.
- Add tests for more folder naming edge cases in our collections.
- Add simple example of filtering to the readme.
- Add a `--dry-run` option to see what will be found/filtered.
- Allow filtering to be done on folders, not just file paths.
- Improve path normalisation. We want to maintain the paths the user specified, not convert symlinks.
- Run file scanning in parallel with preparation workers
- Use S2 Tile metadata over product metadata when they both exist