### PR TITLE
Add an --index option to s2 prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,11 @@ can be as follows:
 module use -a /g/data/v10/private/modules/modulefiles /g/data/v10/public/modules/modulefiles
 module load eodatasets3
 
-# With a full list of input paths, 4 workers, and separate output directory:
-eo3-prepare sentinel-l1 -j 4 --output-base my-metadata-directory
-   -f l1cs-2022-05-02.txt
+# With a folder of input paths, 4 workers, and separate output directory:
+eo3-prepare sentinel-l1 -j 4 --output-base /output/metadata/directory \
   /g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2021
 
-# Filtered to a certain region list and recent months:
+# Using a file for input paths. Filter them to a certain region list and recent months:
 eo3-prepare sentinel-l1 \
     --output-base /g/data/v10/agdc/jez/c3/L1C  \
     --limit-regions-file test-regions.txt \

--- a/README.md
+++ b/README.md
@@ -174,15 +174,16 @@ or region, if the inputs follow a common directory structure:
 
 ```
 ❯ eo3-prepare sentinel-l1 --help
-Usage: eo3-prepare sentinel-l1 [OPTIONS] [DATASETS]...
-
   Prepare eo3 metadata for Sentinel-2 Level 1C data produced by Sinergise or
-  esa.
+  ESA.
 
   Takes ESA zipped datasets or Sinergise dataset directories
 
 Options:
   -v, --verbose
+  -f, --datasets-path FILE        A file to read input dataset paths from, one
+                                  per line
+  -j, --jobs INTEGER              Number of workers to run in parallel
   --overwrite-existing / --skip-existing
                                   Overwrite if exists (otherwise skip)
   --embed-location / --no-embed-location
@@ -198,14 +199,22 @@ Options:
   --input-relative-to DIRECTORY   Input root folder that should be used for
                                   the subfolder hierarchy in the output-base
   --limit-regions-file FILE       A file containing the list of region codes
-                                  to limit the scan to
+                                  to limit the scan to. (Note that some older
+                                  ESA datasets have no region code, and will
+                                  not match any region here.)
   --after-month YEAR-MONTH        Limit the scan to datasets newer than a
                                   given month (expressed as {year}-{month}, eg
                                   '2010-01')
   --before-month YEAR-MONTH       Limit the scan to datasets older than the
                                   given month (expressed as {year}-{month}, eg
                                   '2010-01')
+  -E, --env TEXT
+  -C, --config, --config_file TEXT
+  --index                         Index newly-generated metadata into the
+                                  configured datacube
+  --dry-run
   --help                          Show this message and exit.
+
 ```
 
 An example of preparing metadata in a separate directory (not alongside the datasets) at NCI

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Options:
   -C, --config, --config_file TEXT
   --index                         Index newly-generated metadata into the
                                   configured datacube
-  --dry-run
+  --dry-run                       Show what would be created, but don't create
+                                  anything
   --help                          Show this message and exit.
 
 ```

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -18,6 +18,7 @@ import xarray
 from rasterio import DatasetReader
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
+from ruamel.yaml import CommentedMap
 from shapely.geometry.base import BaseGeometry
 
 import eodatasets3
@@ -300,6 +301,9 @@ class DatasetPrepare(Eo3Interface):
             dataset.id = dataset_id or uuid.uuid4()
 
         self._dataset = dataset
+
+        #: The document that was written to disk, if any.
+        self.written_dataset_doc: Optional[CommentedMap] = None
 
         self._measurements = MeasurementBundler()
         self._accessories: Dict[str, Location] = {}
@@ -785,6 +789,7 @@ class DatasetPrepare(Eo3Interface):
             doc, metadata_path.parent, allow_paths_outside_base=False
         )
         serialise.dump_yaml(metadata_path, doc)
+        self.written_dataset_doc = doc
         return self._dataset.id, metadata_path
 
     def done(

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -185,11 +185,11 @@ def _get_stable_id(p: Eo3Interface) -> uuid.UUID:
 
 def prepare_and_write(
     dataset_location: Path,
-    output_yaml: Optional[Path],
+    output_yaml: Path,
     producer: str,
     embed_location: bool = None,
 ) -> Tuple[DatasetDoc, Path]:
-    if embed_location is None and output_yaml:
+    if embed_location is None:
         # Default to embedding the location if they're not in the same folder.
         embed_location = dataset_location.parent != output_yaml.parent
         _LOG.debug(

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -503,7 +503,12 @@ class Job:
     default=False,
     help="Index newly-generated metadata into the configured datacube",
 )
-@click.option("--dry-run", is_flag=True, default=False)
+@click.option(
+    "--dry-run",
+    help="Show what would be created, but don't create anything",
+    is_flag=True,
+    default=False,
+)
 def main(
     output_base: Optional[Path],
     input_relative_to: Optional[Path],

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -678,7 +678,8 @@ def main(
     index = None
     if index_to_odc:
         _LOG.info("Indexing new datasets")
-        _LOG.debug("Indexing to %s", local_config)
+        if local_config:
+            _LOG.debug("Indexing to %s", local_config)
         index = index_connect(local_config, application_name="s2-prepare")
         products = {}
 


### PR DESCRIPTION
The `--index` option allows it to index newly-created datasets immediately into a datacube. It will use the default datacube, but the standard `-E` and `-C` options (and environment variables) are available for specifying a datacube config/environment.

(... and update the readme)


```
❯ eo3-prepare  sentinel-l1 --index  \
    ~/dea/test-data/L1C/2022/2022-03/25S125E-30S130E/S2B_MSIL1C_20210719T010729_N0301_R045_T53LQC_20210719T021248.zip 
```