### PR TITLE
Allow products+types to customise validation

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -28,7 +28,7 @@ from eodatasets3.images import FileWrite, GridSpec, MeasurementBundler, ValidDat
 from eodatasets3.model import AccessoryDoc, DatasetDoc, Location, ProductDoc
 from eodatasets3.names import NamingConventions, dc_uris, namer, resolve_location
 from eodatasets3.properties import Eo3Dict, Eo3Interface
-from eodatasets3.validate import Level, ValidationMessage
+from eodatasets3.validate import Level, ValidationExpectations, ValidationMessage
 from eodatasets3.verify import PackageChecksum
 
 
@@ -812,6 +812,7 @@ class DatasetPrepare(Eo3Interface):
         validate_correctness: bool = True,
         sort_measurements: bool = True,
         expect_geometry: bool = True,
+        expect: ValidationExpectations = None,
     ) -> DatasetDoc:
         """
         Create the metadata doc as an in-memory :class:`eodatasets3.DatasetDoc` instance.
@@ -916,7 +917,9 @@ class DatasetPrepare(Eo3Interface):
 
         if validate_correctness:
             doc = serialise.to_doc(dataset)
-            for m in validate.validate_dataset(doc, expect_geometry=expect_geometry):
+            for m in validate.validate_dataset(
+                doc, expect or ValidationExpectations(require_geometry=expect_geometry)
+            ):
                 if m.level in (Level.info, Level.warning):
                     warnings.warn(IncompleteDatasetWarning(m))
                 elif m.level == Level.error:

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -918,7 +918,9 @@ class DatasetPrepare(Eo3Interface):
         if validate_correctness:
             doc = serialise.to_doc(dataset)
             for m in validate.validate_dataset(
-                doc, expect or ValidationExpectations(require_geometry=expect_geometry)
+                doc,
+                expect=expect
+                or ValidationExpectations(require_geometry=expect_geometry),
             ):
                 if m.level in (Level.info, Level.warning):
                     warnings.warn(IncompleteDatasetWarning(m))

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -27,6 +27,23 @@ def product():
         license="CC-BY-SA-4.0",
         metadata_type="eo3",
         measurements=[dict(name="blue", units="1", dtype="uint8", nodata=255)],
+        default_allowances=dict(
+            # Allow anything used in test data. We don't need to test this warning except when done explicitly.
+            allow_extra_measurements=[
+                "cirrus",
+                "coastal_aerosol",
+                "blue",
+                "green",
+                "lwir_1",
+                "lwir_2",
+                "nir",
+                "panchromatic",
+                "quality",
+                "red",
+                "swir_1",
+                "swir_2",
+            ],
+        ),
     )
 
 
@@ -214,9 +231,7 @@ class ValidateRunner:
                 self.result.exit_code == 1
             ), f"Expected error code 1 for 1 invalid path. Got {sorted(self.messages.items())}"
 
-    def run_validate(
-        self, docs: Sequence[Doc], allow_extra_measurements=True, suffix=".yaml"
-    ):
+    def run_validate(self, docs: Sequence[Doc], suffix=".yaml"):
         __tracebackhide__ = operator.methodcaller("errisinstance", AssertionError)
 
         args = ("-f", "plain")
@@ -227,8 +242,6 @@ class ValidateRunner:
             args += ("-W",)
         if self.thorough:
             args += ("--thorough",)
-        if allow_extra_measurements:
-            args += ("--expect-extra-measurements",)
 
         for i, doc in enumerate(docs):
             if isinstance(doc, Mapping):


### PR DESCRIPTION
This is less fragile than turning off validation manually from the command line: each product can say what exceptions it _expects_ in its own datasets.

For example, the product definition could be updated to say that geometry is optional on its datasets:

```
default_allowances:
    require_geometry: False
```

... and then the validator will not throw an error for it.

This is driven by the desire to make the DEA product config more manageable -- we can update products with their validation settings to fix the current build.