### PR TITLE
Do subfolder calculation *after* expanding folders

### DIFF
--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -528,7 +528,8 @@ def main(
     dry_run: bool,
     index_to_odc: bool,
 ):
-    output_base = normalise_path(output_base)
+    output_base = normalise_path(output_base) if output_base else None
+
     if sys.argv[1] == "sentinel-l1c":
         warnings.warn(
             "Command name 'sentinel-l1c-prepare' is deprecated: remove the 'c', and use `sentinel-l1-prepare`"

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -192,7 +192,7 @@ def prepare_and_write(
 ) -> Tuple[DatasetDoc, Path]:
     if embed_location is None:
         # Default to embedding the location if they're not in the same folder.
-        embed_location = dataset_location.parent != output_yaml.parent
+        embed_location = output_yaml.parent not in dataset_location.parents
         _LOG.debug(
             "Auto-embed location? %s: %s %s %s",
             "Yes" if embed_location else "No",

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -528,8 +528,6 @@ def main(
     dry_run: bool,
     index_to_odc: bool,
 ):
-    output_base = normalise_path(output_base) if output_base else None
-
     if sys.argv[1] == "sentinel-l1c":
         warnings.warn(
             "Command name 'sentinel-l1c-prepare' is deprecated: remove the 'c', and use `sentinel-l1-prepare`"
@@ -545,7 +543,10 @@ def main(
     if datasets_path:
         datasets = [
             *datasets,
-            *(Path(p.strip()) for p in (datasets_path.read_text().splitlines())),
+            *(
+                normalise_path(p.strip())
+                for p in (datasets_path.read_text().splitlines())
+            ),
         ]
 
     _LOG.info(f"{len(datasets)} paths(s) to process using {workers} worker(s))")
@@ -587,7 +588,6 @@ def main(
             datasets, label="Preparing metadata", show_pos=True
         ) as progress:
             for i, input_path in enumerate(progress):
-                input_path = normalise_path(input_path)
 
                 first = True
                 for producer, ds_path, sibling_yaml_path in files_in_path(input_path):

--- a/eodatasets3/ui.py
+++ b/eodatasets3/ui.py
@@ -5,13 +5,15 @@ from typing import Optional, Union
 from urllib.parse import urljoin, urlparse
 
 import click
+from datacube.utils.uris import normalise_path
 
 
 class PathPath(click.Path):
-    """A Click path argument that returns a pathlib Path, not a string"""
+    """
+    A Click argument that returns a normalised (absolute) pathlib Path"""
 
     def convert(self, value, param, ctx):
-        return Path(super().convert(value, param, ctx))
+        return Path(normalise_path(super().convert(value, param, ctx)))
 
 
 def uri_resolve(base: Union[str, Path], path: Optional[str]) -> str:

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -408,10 +408,12 @@ def test_filter_folder_structure_info(
         input_dataset_path if input_dataset_path.is_dir() else input_dataset_path.parent
     )
 
+    input_folder = tmp_path / "inputs"
+
     subfolders = "2019/2019-01/25S125E-30S130"
 
     # Move input data into subfolder hierarchy.
-    dataset_folder = tmp_path / "L1C" / subfolders
+    dataset_folder = input_folder / "L1C" / subfolders
     dataset_folder.mkdir(parents=True)
     new_input_dataset_path = dataset_folder / input_dataset_path.name
     input_dataset_path.rename(new_input_dataset_path)
@@ -516,6 +518,25 @@ def test_filter_folder_structure_info(
             "--output-base",
             output_folder,
             input_dataset_path,
+        ],
+        expected_doc=expected_metadata_doc,
+        expected_metadata_path=expected_metadata_path,
+    )
+
+    # Now run again using a folder input, not an exact zip input.
+    # (so it has to scan for datasets)
+    shutil.rmtree(output_folder)
+    output_folder.mkdir()
+
+    # Now run for real, expect an output.
+    check_prepare_outputs(
+        invoke_script=sentinel_l1_prepare.main,
+        run_args=[
+            # "Put the output in a different location":
+            "--output-base",
+            output_folder,
+            # The base folder, so it has to scan for zip files itself!
+            input_folder,
         ],
         expected_doc=expected_metadata_doc,
         expected_metadata_path=expected_metadata_path,

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -379,14 +379,11 @@ def dataset_input_output(request, tmp_path):
 
     if input_dataset_path.is_dir():
         shutil.copytree(input_dataset_path, unique_in_path)
-        # A folder input expects a metadata file inside.
-        expected_metadata_path = (
-            tmp_path / input_dataset_path.name / expected_metadata_name
-        )
     else:
         shutil.copy(input_dataset_path, unique_in_path)
-        # A file expects a sibling metadata path.
-        expected_metadata_path = tmp_path / expected_metadata_name
+
+    # A file expect a sibling metadata path.
+    expected_metadata_path = tmp_path / expected_metadata_name
 
     return (
         unique_in_path,
@@ -404,9 +401,7 @@ def test_filter_folder_structure_info(
         expected_metadata_path,
     ) = dataset_input_output
 
-    metadata_offset = expected_metadata_path.relative_to(
-        input_dataset_path if input_dataset_path.is_dir() else input_dataset_path.parent
-    )
+    metadata_offset = expected_metadata_path.relative_to(input_dataset_path.parent)
 
     input_folder = tmp_path / "inputs"
 


### PR DESCRIPTION
- Fixes lack of sub-folders (and error about no relative path found) when directory scanning is used in some cases.
- Normalise all folder paths consistently.
- Includes tests.