### PR TITLE
Fix indexing of datasets with embedded locations

### DIFF
--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -26,7 +26,7 @@ from datacube.ui.click import config_option, environment_option
 from datacube.utils.uris import normalise_path
 from defusedxml import minidom
 
-from eodatasets3 import DatasetDoc, DatasetPrepare, serialise
+from eodatasets3 import DatasetDoc, DatasetPrepare, names, serialise
 from eodatasets3.properties import Eo3Interface
 from eodatasets3.ui import PathPath
 from eodatasets3.utils import pass_config
@@ -248,6 +248,8 @@ def prepare_and_write(
         doc = serialise.from_doc(
             p.written_dataset_doc, skip_validation=True, normalise_properties=False
         )
+        if not doc.locations:
+            doc.locations = [names.resolve_location(dataset_location)]
         return doc, metadata_path
 
 

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -688,7 +688,7 @@ def main(
 
                     if output_yaml.exists():
                         if not overwrite_existing:
-                            _LOG.debug("Output exists: not writing. %s", output_yaml)
+                            _LOG.debug("Output exists: skipping. %s", output_yaml)
                             continue
 
                         _LOG.debug("Output exists: overwriting %s", output_yaml)
@@ -727,7 +727,7 @@ def main(
                         on_success(dataset, path)
                     successes += 1
                 except Exception:
-                    _LOG.exception("Failed to write dataset: %s", job)
+                    _LOG.exception("Failed to complete dataset: %s", job)
                     errors += 1
         else:
             with Pool(processes=workers) as pool:

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -572,7 +572,9 @@ def main(
                     raise ValueError(f"Product {product_name} not found in ODC index")
                 products[product_name] = product
 
-            index.datasets.add(Dataset(product, serialise.to_doc(dataset)))
+            index.datasets.add(
+                Dataset(product, serialise.to_doc(dataset), uris=dataset.locations)
+            )
             _LOG.debug("Indexed dataset %s to %s", dataset.id, dataset_path)
 
     else:


### PR DESCRIPTION
Explicitly always give ODC a location for indexed datasets.

(When the location is inside the document, rather than external via filesystem, the normal indexing api was not recognising them.)

