### PR TITLE
Add a cheaper way to skip datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Options:
                                   for multi-granule files). Beware that multi-
                                   granule datasets without a granule id in the
                                   filename will overwrite each-other
+  --throughly-check-existing / --cheaply-check-existing
+                                  Should we open every dataset to check if
+                                  *all* inner granules have been produced?
+                                  Default: false.
   --provider [sinergise.com|esa.int]
                                   Restrict scanning to only packages of the
                                   given provider. (ESA assumes a zip file,


### PR DESCRIPTION
It can be really expensive to check all inner granules of every dataset to know what has been processed already. 

This PR changes the default behaviour to skip datasets immediately if _any_ outputs exist at all, using their filename. 

The downside of this is that a multi-granule dataset that whose packaging was interrupted may have some granules missing from the outputs, and this will skip it rather than check them all.

I've added the flag `--thoroughly-check-existing` to make it (run slower and) actually check all inner granules are processed.

Example:
```
eo3-prepare sentinel-l1 \
    --throughly-check-existing  \
    dev/S2A_MSIL1C_20201031T004711_N0209_R102_T53JQJ_20201031T022859.zip \
    dev/S2A_OPER_PRD_MSIL1C_PDMC_20161213T162432_R088_V20151007T012016_20151007T012016.zip 
```