### PR TITLE
add yaml representer for float to strictly display scientic format

### DIFF
--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -62,6 +62,11 @@ def _represent_paths(self, data: PurePath):
     return Representer.represent_str(self, data.as_posix())
 
 
+def _represent_float(self, data: float):
+    float_text = numpy.format_float_scientific(data)
+    return self.represent_scalar(u'tag:yaml.org,2002:float', float_text)
+
+
 def _init_yaml() -> YAML:
     yaml = YAML()
 
@@ -81,6 +86,7 @@ def _init_yaml() -> YAML:
     yaml.representer.add_representer(numpy.uint64, Representer.represent_int)
     yaml.representer.add_representer(numpy.float32, Representer.represent_float)
     yaml.representer.add_representer(numpy.float64, Representer.represent_float)
+
     yaml.representer.add_representer(numpy.ndarray, Representer.represent_list)
     yaml.representer.add_representer(numpy.datetime64, _represent_numpy_datetime)
 
@@ -105,7 +111,9 @@ def dump_yaml(output_yaml: Path, *docs: Mapping) -> None:
 
 def dumps_yaml(stream, *docs: Mapping) -> None:
     """Dump yaml through a stream, using the default serialisation settings."""
-    return _init_yaml().dump_all(docs, stream=stream)
+    yml = _init_yaml()
+    yml.representer.add_representer(float, _represent_float)
+    return yml.dump_all(docs, stream=stream)
 
 
 def load_yaml(p: Path) -> Dict:

--- a/tests/test_serialise.py
+++ b/tests/test_serialise.py
@@ -1,0 +1,11 @@
+from eodatasets3 import serialise
+from io import StringIO
+
+
+def test_dumps_yaml_scientific_notation():
+    stream = StringIO()
+    serialise.dumps_yaml(stream, {'response': [7e-06, 7e-06, 8e-06]})
+    assert type(stream.getvalue()) == str
+    assert stream.getvalue().split()[3] == '7.e-06'
+    assert stream.getvalue().split()[5] == '7.e-06'
+    assert stream.getvalue().split()[7] == '8.e-06'


### PR DESCRIPTION
Fixes #260 and fixes downstream issue https://github.com/opendatacube/datacube-explorer/issues/223

linked pr: https://github.com/opendatacube/datacube-explorer/pull/399