### PR TITLE
Handle S2 L1 files with extra QA data

### DIFF
--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -64,7 +64,7 @@ def _represent_paths(self, data: PurePath):
 
 def _represent_float(self, data: float):
     float_text = numpy.format_float_scientific(data)
-    return self.represent_scalar(u'tag:yaml.org,2002:float', float_text)
+    return self.represent_scalar("tag:yaml.org,2002:float", float_text)
 
 
 def _init_yaml() -> YAML:

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -20,7 +20,7 @@ def test_subfolder_info_extraction():
         )
     )
     assert info is not None
-    assert info == FolderInfo(2019, 1, '25S125E-30S130', "32UJ")
+    assert info == FolderInfo(2019, 1, "25S125E-30S130", "32UJ")
 
     info = FolderInfo.for_path(
         Path(
@@ -36,7 +36,7 @@ def test_subfolder_info_extraction():
             "S2B_MSIL1C_20210719T010729_N0301_R045_T53LQC_20210719T021248.zip"
         )
     )
-    assert info == FolderInfo(2022, 3, '25S125E-30S130E', "53LQC")
+    assert info == FolderInfo(2022, 3, "25S125E-30S130E", "53LQC")
 
     info = FolderInfo.for_path(
         Path(
@@ -44,7 +44,7 @@ def test_subfolder_info_extraction():
             "S2B_MSIL1C_20210716T035539_N0301_R004_T47QMB_20210716T063913.zip"
         )
     )
-    assert info == FolderInfo(2021, 7, '20N095E-15N100E', "47QMB")
+    assert info == FolderInfo(2021, 7, "20N095E-15N100E", "47QMB")
 
     # Older dataset structure had no region code
     info = FolderInfo.for_path(
@@ -53,9 +53,9 @@ def test_subfolder_info_extraction():
             "S2A_OPER_PRD_MSIL1C_PDMC_20151225T022834_R072_V20151224T223838_20151224T223838.zip"
         )
     )
-    assert info == FolderInfo(2015, 12, '30S170E-35S175E', None)
+    assert info == FolderInfo(2015, 12, "30S170E-35S175E", None)
     # But it can be looked up?
-    assert '59HPB' in RegionLookup().get(info.area)
+    assert "59HPB" in RegionLookup().get(info.area)
 
     # A sinergise-like input path.
     info = FolderInfo.for_path(
@@ -64,7 +64,7 @@ def test_subfolder_info_extraction():
             "S2B_MSIL1C_20190111T000249_N0209_R030_T55HFA_20190111T011446/tileInfo.json"
         )
     )
-    assert info == FolderInfo(2019, 1, '25S125E-30S130', "55HFA")
+    assert info == FolderInfo(2019, 1, "25S125E-30S130", "55HFA")
 
     # A folder that doesn't follow standard layout will return no info
     info = FolderInfo.for_path(
@@ -83,16 +83,16 @@ SINERGISE_INPUT_DATASET: Path = Path(__file__).parent.parent / (
 )
 
 ESA_MULTIGRANULE_DATASET: Path = (
-        Path(__file__).parent.parent
-        / "data/multi-granule/S2A_OPER_PRD_MSIL1C_PDMC_20161213T162432_R088_V20151007T012016_20151007T012016.zip"
+    Path(__file__).parent.parent
+    / "data/multi-granule/S2A_OPER_PRD_MSIL1C_PDMC_20161213T162432_R088_V20151007T012016_20151007T012016.zip"
 )
 assert ESA_MULTIGRANULE_DATASET.exists()
 
 # This one has some quirky metadata. No resolution, etc.
 ESA_MULTIGRANULE_DATASET_FOLDERS: Path = (
-        Path(__file__).parent.parent
-        / "data/multi-granule/L1C/2016/2016-01/25S135E-30S140E/"
-          "S2A_OPER_PRD_MSIL1C_PDMC_20160210T005347_R002_V20160129T010047_20160129T010047.zip"
+    Path(__file__).parent.parent
+    / "data/multi-granule/L1C/2016/2016-01/25S135E-30S140E/"
+    "S2A_OPER_PRD_MSIL1C_PDMC_20160210T005347_R002_V20160129T010047_20160129T010047.zip"
 )
 
 ESA_EXPECTED_METADATA = {
@@ -163,57 +163,57 @@ ESA_EXPECTED_METADATA = {
         "blue": {
             "grid": "50",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B02.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B02.jp2",
         },
         "coastal_aerosol": {
             "grid": "300",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B01.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B01.jp2",
         },
         "green": {
             "grid": "50",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B03.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B03.jp2",
         },
         "nir_1": {
             "grid": "50",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B08.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B08.jp2",
         },
         "red": {
             "grid": "50",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B04.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B04.jp2",
         },
         "red_edge_1": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B05.jp2"
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B05.jp2"
         },
         "red_edge_2": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B06.jp2"
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B06.jp2"
         },
         "red_edge_3": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B07.jp2"
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B07.jp2"
         },
         "swir_1_cirrus": {
             "grid": "300",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B10.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B10.jp2",
         },
         "swir_2": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B11.jp2"
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B11.jp2"
         },
         "swir_3": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B12.jp2"
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B12.jp2"
         },
         "water_vapour": {
             "grid": "300",
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B09.jp2",
+            "L1C_T55HFA_A018789_20201011T000244/IMG_DATA/T55HFA_20201011T000249_B09.jp2",
         },
     },
     "product": {"name": "esa_s2bm_level1_0"},
@@ -246,14 +246,14 @@ ESA_EXPECTED_METADATA = {
     "accessories": {
         "metadata:s2_datastrip": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/DATASTRIP/"
-                    "DS_EPAE_20201011T011446_S20201011T000244/MTD_DS.xml"
+            "DS_EPAE_20201011T011446_S20201011T000244/MTD_DS.xml"
         },
         "metadata:s2_user_product": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/MTD_MSIL1C.xml"
         },
         "metadata:s2_tile": {
             "path": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446.SAFE/GRANULE/"
-                    "L1C_T55HFA_A018789_20201011T000244/MTD_TL.xml"
+            "L1C_T55HFA_A018789_20201011T000244/MTD_TL.xml"
         },
     },
 }
@@ -415,7 +415,7 @@ def dataset_input_output(request, tmp_path):
 
 
 def test_filter_folder_structure_info(
-        tmp_path: Path, dataset_input_output: Tuple[Path, Dict, Path]
+    tmp_path: Path, dataset_input_output: Tuple[Path, Dict, Path]
 ):
     (
         input_dataset_path,
@@ -609,9 +609,15 @@ def test_run_multigranule(tmp_path: Path):
 
 def check_input_dir_normal():
     # Sanity check: there should be no sibling files in the input directory
-    non_zip_files = [f for f in ESA_MULTIGRANULE_DATASET.parent.rglob('*') if f.is_file() and f.suffix != '.zip']
-    assert not non_zip_files, ("Test data directory contains files that aren't zips. "
-                               f"Did a prepare tool dirty the input directory? Found: {non_zip_files}")
+    non_zip_files = [
+        f
+        for f in ESA_MULTIGRANULE_DATASET.parent.rglob("*")
+        if f.is_file() and f.suffix != ".zip"
+    ]
+    assert not non_zip_files, (
+        "Test data directory contains files that aren't zips. "
+        f"Did a prepare tool dirty the input directory? Found: {non_zip_files}"
+    )
 
 
 def test_run_unusual_multigranule(tmp_path: Path):
@@ -658,13 +664,12 @@ def test_run_unusual_multigranule(tmp_path: Path):
         f"{dataset_name}.S2A_OPER_MSI_L1C_TL_MTI__20160209T133001_A003145_T53JQK_N02.01.odc-metadata.yaml",
         f"{dataset_name}.S2A_OPER_MSI_L1C_TL_MTI__20160209T133001_A003145_T54JTN_N02.01.odc-metadata.yaml",
         f"{dataset_name}.S2A_OPER_MSI_L1C_TL_MTI__20160209T133001_A003145_T54JTP_N02.01.odc-metadata.yaml",
-        f"{dataset_name}.S2A_OPER_MSI_L1C_TL_MTI__20160209T133001_A003145_T54JTQ_N02.01.odc-metadata.yaml"
-
+        f"{dataset_name}.S2A_OPER_MSI_L1C_TL_MTI__20160209T133001_A003145_T54JTQ_N02.01.odc-metadata.yaml",
     ]
 
 
 def test_generate_expected_outputs(
-        tmp_path: Path, dataset_input_output: Tuple[Path, Dict, Path]
+    tmp_path: Path, dataset_input_output: Tuple[Path, Dict, Path]
 ):
     """
     Run prepare on our test input scenes, and check the created metadata matches expected.

--- a/tests/test_serialise.py
+++ b/tests/test_serialise.py
@@ -4,8 +4,8 @@ from io import StringIO
 
 def test_dumps_yaml_scientific_notation():
     stream = StringIO()
-    serialise.dumps_yaml(stream, {'response': [7e-06, 7e-06, 8e-06]})
+    serialise.dumps_yaml(stream, {"response": [7e-06, 7e-06, 8e-06]})
     assert type(stream.getvalue()) == str
-    assert stream.getvalue().split()[3] == '7.e-06'
-    assert stream.getvalue().split()[5] == '7.e-06'
-    assert stream.getvalue().split()[7] == '8.e-06'
+    assert stream.getvalue().split()[3] == "7.e-06"
+    assert stream.getvalue().split()[5] == "7.e-06"
+    assert stream.getvalue().split()[7] == "8.e-06"


### PR DESCRIPTION
These extra qa xml files have very similar filenames to the normal metadata filenames, so eod3 baulked at finding multiple.

Added this example to our test data.

I've also moved the s2 packager to structlog to match other modules -- the test error messages were fairly useless before.