### PR TITLE
inherit setuid/setgid permissions in output folders

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1694,7 +1694,7 @@ class DatasetAssembler(DatasetPrepare):
 
         # Match the lower r/w permission bits to the output folder.
         # (Temp directories default to 700 otherwise.)
-        self._work_path.chmod(self._target_collection_path().stat().st_mode & 0o777)
+        self._work_path.chmod(self._target_collection_path().stat().st_mode & 0o7777)
 
         # GDAL writes extra metadata in aux files,
         # but we consider it a mistake if you're using those extensions.


### PR DESCRIPTION
If a folder has the setuid/setgid permissions bits set, then our own subfolders inside them should have it too.

The lack of these bits has caused permissions issues on NCI, where files must be set to the correct group differnetly for each storage location.