### PR TITLE
change error to warning for nodata value mismatch

### DIFF
--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -531,7 +531,7 @@ def validate_product(doc: Dict) -> ValidationMessages:
             dtype = measurement.get("dtype")
             nodata = measurement.get("nodata")
             if not numpy_value_fits_dtype(nodata, dtype):
-                yield _error(
+                yield _warning(
                     "unsuitable_nodata",
                     f"Measurement {measurement_name!r} nodata {nodata!r} does not fit a {dtype!r}",
                 )


### PR DESCRIPTION
Fixes opendatacube/datacube-core#1348 

odc accepts this value, so its not an error. It ideally should match but its not an error,

related to https://github.com/opendatacube/datacube-core/pull/1347