### PR TITLE
Improve EO3 dataset schema validation

### DIFF
--- a/eodatasets3/dataset.schema.yaml
+++ b/eodatasets3/dataset.schema.yaml
@@ -86,7 +86,7 @@ properties:
   measurements:
     type: object
     propertyNames:
-      pattern: "^[a-z_][a-z0-9_]*$"
+      pattern: "^[a-zA-Z0-9_]*$"
     additionalProperties:
       title: Measurement
       type: object

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -209,12 +209,16 @@ def from_doc(doc: Dict, skip_validation=False) -> DatasetDoc:
     :param skip_validation: Optionally disable validation (it's faster, but I hope your
             doc is structured correctly)
     """
-
+    doc = doc.copy()
     if not skip_validation:
+        # don't error if properties 'extent' or 'grid_spatial' are present
+        if doc.get("extent"):
+            del doc["extent"]
+        if doc.get("grid_spatial"):
+            del doc["grid_spatial"]
         DATASET_SCHEMA.validate(doc)
 
     # TODO: stable cattrs (<1.0) balks at the $schema variable.
-    doc = doc.copy()
     del doc["$schema"]
     location = doc.pop("location", None)
     if location:


### PR DESCRIPTION
See #268 

Improve compatibility between EO3 dataset schema and ODC metadata by allowing for uppercase letters in measurement names and removing "extent" and "grid_spatial" properties before schema validation to effectively ignore them, as they ultimately have no impact anyway.