### PR TITLE
Prepared S2 L1 filters that fail indexing should be cleaned up

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ from eodatasets3 import DatasetAssembler
 with DatasetAssembler(
     Path("/some/output/collection/path"), naming_conventions="default"
 ) as p:
-
     # Add some common metadata fields.
     p.platform = "landsat-7"
     p.instrument = "ETM"

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -670,7 +670,6 @@ class DatasetPrepare(Eo3Interface):
         source_dataset: DatasetDoc,
         inherit_skip_properties: Optional[List[str]] = None,
     ):
-
         if not inherit_skip_properties:
             # change the inherit_skip_properties to [] if it is None. Make the 'in list check' easier.
             inherit_skip_properties = []

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -901,7 +901,11 @@ class FileWrite:
         out_crs = ql_grid.crs
 
         # Scale and write as JPEG to the output.
-        (thumb_transform, thumb_width, thumb_height,) = calculate_default_transform(
+        (
+            thumb_transform,
+            thumb_width,
+            thumb_height,
+        ) = calculate_default_transform(
             out_crs,
             out_crs,
             ql_grid.shape[1],

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -655,7 +655,6 @@ class NamingConventions:
         dataset_separator_field: Optional[str] = None,
         allow_unknown_abbreviations: bool = True,
     ) -> None:
-
         #: The default base URI used in product URI generation
         #:
         #: Example: ``https://collections.dea.ga.gov.au/``

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -296,7 +296,6 @@ def read_mtl(fp: Iterable[Union[str, bytes]], root_element=None) -> Tuple[Dict, 
         lines: Iterable[Union[str, bytes]],
         key_transform: Callable[[str], str] = lambda s: s.lower(),
     ) -> dict:
-
         tree = {}
         for line in lines:
             # If line is bytes-like convert to str

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -976,6 +976,10 @@ def main(
                             # If the post-processing function fails, we don't want this "unfinished" file still around.
                             # We'd rather let it be re-created next time.
                             if not file_already_existed:
+                                _LOG.info(
+                                    "Cleaning new file due to indexing failure.",
+                                    output_yaml=job.output_yaml_path,
+                                )
                                 job.output_yaml_path.unlink()
 
                             raise

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -966,7 +966,7 @@ def main(
                         _LOG.info(
                             "Wrote dataset",
                             dataset_id=dataset.id,
-                            datsaset_path=path,
+                            dataset_path=path,
                             output_yaml=job.output_yaml_path,
                         )
 

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -909,7 +909,6 @@ def _match_product(
 
     # We we have nothing, give up!
     if (not matching_products) and (not product):
-
         # Find the product that most closely matches it, to helpfully show the differences!
         closest_product_name = None
         closest_differences = None
@@ -1292,7 +1291,6 @@ def _load_remote_product_definitions(
     from_datacube: bool = False,
     from_explorer_url: Optional[str] = None,
 ) -> Dict[str, Dict]:
-
     product_definitions = {}
     # Load any remote products that were asked for.
     if from_explorer_url:

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -92,7 +92,6 @@ def _unpack_products(
     for product in product_list:
         with sub_product(product, p):
             for pathname in [p for p in img_paths if f"/{product.upper()}/" in p]:
-
                 with do(f"Path {pathname!r}"):
                     dataset = h5group[pathname]
                     band_name = utils.normalise_band_name(dataset.attrs["alias"])
@@ -225,7 +224,6 @@ def get_oa_resolution_group(
     platform: str,
     oa_resolution: Optional[Tuple[float, float]],
 ) -> h5py.Group:
-
     # None specified? Figure out a default.
 
     if oa_resolution is None:
@@ -532,7 +530,6 @@ def _load_level1_doc(
     user_specified_l1_path: Optional[Path] = None,
     allow_missing_provenance=False,
 ):
-
     if user_specified_l1_path:
         if not user_specified_l1_path.exists():
             raise ValueError(

--- a/tests/integration/prepare/test_esri_land_cover.py
+++ b/tests/integration/prepare/test_esri_land_cover.py
@@ -17,7 +17,6 @@ ESRI_ANTIMERIDIAN_OVERLAP_TIF: Path = (
 
 
 def test_esri_prepare():
-
     tif_url = ESRI_ANTIMERIDIAN_OVERLAP_TIF.resolve().as_uri()
     dataset_doc = as_eo3(tif_url)
 

--- a/tests/integration/prepare/test_prepare_landsat_l1.py
+++ b/tests/integration/prepare/test_prepare_landsat_l1.py
@@ -921,7 +921,6 @@ def expected_lt05_l2_c2_folder():
 
 
 def expected_le07_l2_c2_folder():
-
     return {
         "$schema": "https://schemas.opendatacube.org/dataset",
         "id": "2184a390-3bfc-5393-91fa-e9dae7c3fe39",

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -366,7 +366,6 @@ def test_africa_naming_conventions(tmp_path: Path):
     Minimal fields needed for DEAfrica naming conventions
     """
     with DatasetAssembler(tmp_path, naming_conventions="deafrica") as p:
-
         # Just the fields listed in required_fields.
         p.producer = "digitalearthafrica.org"
         p.datetime = datetime(1998, 7, 30)
@@ -385,7 +384,6 @@ def test_africa_naming_conventions(tmp_path: Path):
     )
 
     with DatasetAssembler(tmp_path, naming_conventions="deafrica") as p:
-
         # Just the fields listed in required_fields.
         p.producer = "digitalearthafrica.org"
         p.datetime = datetime(1998, 7, 30)

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -481,7 +481,6 @@ def test_whole_landsat_wagl_package(
 
 
 def _run_wagl(args):
-
     from eodatasets3.scripts import packagewagl
 
     # No warnings should be logged during package.
@@ -1145,7 +1144,6 @@ def test_esa_sentinel_wagl_package(tmp_path: Path):
 
 
 def test_sinergise_sentinel_wagl_package(tmp_path: Path):
-
     _run_wagl(
         (
             WAGL_SINERGISE_SENTINEL_OUTPUT,

--- a/tests/integration/test_serialise.py
+++ b/tests/integration/test_serialise.py
@@ -43,13 +43,11 @@ def _normalise_datetime_props(generated_doc):
 
 
 def test_location_serialisation(l1_ls8_folder_md_expected: Dict):
-
     l1_ls8_folder_md_expected["location"] = "s3://test/url/metadata.txt"
     assert_unchanged_after_roundstrip(l1_ls8_folder_md_expected)
 
 
 def test_location_single_serialisation(tmp_path: Path, l1_ls8_folder_md_expected: Dict):
-
     # Always serialises a single location as 'location'
     location = "https://some/test/path"
 

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -32,7 +32,6 @@ def expected_stac_doc(input_doc_folder: Path) -> Dict:
 
 
 def test_tostac(odc_dataset_path: Path, expected_stac_doc: Dict):
-
     run_tostac(odc_dataset_path)
 
     expected_output_path = odc_dataset_path.with_name(


### PR DESCRIPTION
We shouldn't leave files around if indexing fails, as this prevents retry of the dataset.

(reported by Duncan)