### PR TITLE
Minor wagl fixes

### DIFF
--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -506,6 +506,8 @@ class Granule:
                         )
                 else:
                     tesp_doc_path = wagl_hdf5.with_name(f"{granule_name}.tesp.yaml")
+
+                tesp_doc = None
                 if tesp_doc_path.exists():
                     with tesp_doc_path.open("r") as fl:
                         [tesp_doc] = loads_yaml(fl)

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -11,6 +11,7 @@ import re
 import sys
 from datetime import datetime, timedelta
 from enum import Enum
+from math import isnan
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 from uuid import UUID
@@ -793,7 +794,7 @@ def _read_gqa_doc(p: DatasetAssembler, doc: Dict):
 def _read_fmask_doc(p: DatasetAssembler, doc: Dict):
     for name, value in doc["percent_class_distribution"].items():
         # From Josh: fmask cloud cover trumps the L1 cloud cover.
-        if name == "cloud":
+        if name == "cloud" and not isnan(value):
             if "eo:cloud_cover" in p.properties:
                 del p.properties["eo:cloud_cover"]
             p.properties["eo:cloud_cover"] = value


### PR DESCRIPTION
A few more fixes that have caused some minor failures.

- When no tesp doc was found by the wrapper, a variable was being referenced without initialisation, causing a python error.
- NaN cloud values shouldn't override existing numbers. This NaNs would cause failures on a few datasets in downstream processing.
