### PR TITLE
Misc cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "xarray",
         "datacube",
         "python-rapidjson",
-        "pystac>=1.1.0",
+        "pystac>=1.7",
     ],
     tests_require=tests_require,
     extras_require=EXTRAS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "eodatasets3": ["eodatasets3/py.typed"],
     },
     license="Apache Software License 2.0",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
@@ -65,7 +65,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
-    url="https://github.com/GeoscienceAustralia/eo-datasets",
+    url="https://github.com/opendatacube/eo-datasets",
     install_requires=[
         "affine",
         "attrs>=18.1",  # 18.1 adds 'factory' syntactic sugar
@@ -101,7 +101,7 @@ setup(
         eo3-to-stac=eodatasets3.scripts.tostac:run
     """,
     project_urls={
-        "Bug Reports": "https://github.com/GeoscienceAustralia/eo-datasets/issues",
-        "Source": "https://github.com/GeoscienceAustralia/eo-datasets",
+        "Bug Reports": "https://github.com/opendatacube/eo-datasets/issues",
+        "Source": "https://github.com/opendatacube/eo-datasets",
     },
 )

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -1138,7 +1138,7 @@
   ],
   "stac_extensions": [
       "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
-      "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "collection": "ga_ls8c_ard_3"

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -124,7 +124,7 @@ def test_calc_range():
         ]
     )
 
-    mask = np.ones(r_array.shape, dtype=np.bool)
+    mask = np.ones(r_array.shape, dtype=np.bool_)
     calculated_range = images.read_valid_mask_and_value_range(
         mask,
         ((r_array, no), (g_array, no), (b_array, no)),


### PR DESCRIPTION
- Update organisation in github urls in `setup.py` from `GeoScienceAustralia` to `opendatacube`
- Update tests for latest versions of numpy (use `numpy.bool_` instead of `numpy.bool` - the latter has been deprecated since I think 1.18 and dropped in 1.24)
- pystac 1.7 now supports STAC projection extension v1.1.0, which means the old tests fail.  I've updated setup.py pin to `pystac>=1.7`.  The other option is rolling back the the expected projection version to 1.0.0 and pinning `pystac>1.1.0,<1.7`