### PR TITLE
Fix pystac conversion for datasets with a datetime range

### DIFF
--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -243,8 +243,9 @@ def to_pystac_item(
     properties = eo3_to_stac_properties(dataset, title=dataset.label)
     properties.update(_lineage_fields(dataset.lineage))
 
-    dt = properties["datetime"]
-    del properties["datetime"]
+    dt = properties.get("datetime")
+    if dt is not None:
+        del properties["datetime"]
 
     # TODO: choose remote if there's multiple locations?
     # Without a dataset location, all paths will be relative.


### PR DESCRIPTION
`stac.to_pystac_item` assumes that the dataset will include the `datetime` property. However some datasets, like `s2_barest_earth`, include only `start_datetime` and `end_datetime`, causing an error when preparing the dataset for conversion to a pystac Item.
Note that the Item `datetime` parameter can be `None` if `start_datetime` and `end_datetime` are provided in the properties, which they would be in the case of such datasets, so no `datetime` calculation/approximation is necessary here.