### PR TITLE
Fix deprecated `crs.crs_str`

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1,6 +1,7 @@
 """
 API for easily writing an ODC Dataset
 """
+
 import shutil
 import tempfile
 import uuid
@@ -452,8 +453,7 @@ class DatasetPrepare(Eo3Interface):
     def __enter__(self) -> "DatasetPrepare":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        ...
+    def __exit__(self, exc_type, exc_val, exc_tb): ...
 
     @property
     def collection_location(self) -> Path:

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -146,7 +146,7 @@ class GridSpec:
         return cls(
             shape=shape,
             transform=dataset.geobox.transform,
-            crs=CRS.from_wkt(dataset.geobox.crs.crs_str),
+            crs=CRS.from_wkt(str(dataset.geobox.crs)),
         )
 
     @classmethod

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -334,8 +334,7 @@ class LazyDatasetLocation:
         return f"{c.collection_prefix}/{offset}/"
 
 
-class MissingRequiredFields(ValueError):
-    ...
+class MissingRequiredFields(ValueError): ...
 
 
 class RequiredPropertyDict(Eo3Dict):

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -3,6 +3,7 @@ Prepare eo3 metadata for Sentinel-2 Level 1C data produced by Sinergise or ESA.
 
 Takes ESA zipped datasets or Sinergise dataset directories
 """
+
 import fnmatch
 import json
 import os.path

--- a/eodatasets3/scripts/packagewagl.py
+++ b/eodatasets3/scripts/packagewagl.py
@@ -5,6 +5,7 @@ This will convert the HDF5 file (and sibling fmask/gqa files) into
 GeoTIFFS (COGs) with datacube metadata using the DEA naming conventions
 for files.
 """
+
 from pathlib import Path
 from typing import Optional, Sequence
 

--- a/eodatasets3/scripts/tostac.py
+++ b/eodatasets3/scripts/tostac.py
@@ -1,6 +1,7 @@
 """
 Convert an EO3 metadata doc to a Stac Item.
 """
+
 import json
 from datetime import datetime
 from pathlib import Path

--- a/eodatasets3/stac.py
+++ b/eodatasets3/stac.py
@@ -1,6 +1,7 @@
 """
 Convert an EO3 metadata doc to a Stac Item. (BETA/Incomplete)
 """
+
 import datetime
 import math
 import mimetypes

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -1,6 +1,7 @@
 """
 Validate ODC dataset documents
 """
+
 import collections
 import enum
 import math
@@ -956,11 +957,13 @@ def _match_product(
             _error(
                 "product_match_clash",
                 "Multiple products match the given dataset",
-                hint=f"Maybe you need more fields in the 'metadata' section?\n"
-                f"Claims to be a {specified_product_name!r}, and matches {matching_names!r}"
-                if specified_product_name
-                else f"Maybe you need more fields in the 'metadata' section?\n"
-                f"Matches {matching_names!r}",
+                hint=(
+                    f"Maybe you need more fields in the 'metadata' section?\n"
+                    f"Claims to be a {specified_product_name!r}, and matches {matching_names!r}"
+                    if specified_product_name
+                    else f"Maybe you need more fields in the 'metadata' section?\n"
+                    f"Matches {matching_names!r}"
+                ),
             )
         )
         # (We wont pick one from the bunch here. Maybe they already matched one above to use in continuing validation.)

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -5,6 +5,7 @@ This converts the HDF5 file (and sibling fmask/gqa files) into
 GeoTIFFS (COGs) with datacube metadata using the DEA naming conventions
 for files.
 """
+
 import contextlib
 import os
 import re
@@ -870,9 +871,11 @@ def package(
             out_directory.absolute(),
             # WAGL stamps a good, random ID already.
             dataset_id=granule.wagl_metadata.get("id"),
-            naming_conventions="dea_s2"
-            if ("sentinel" in wagl_doc["source_datasets"]["platform_id"].lower())
-            else "dea",
+            naming_conventions=(
+                "dea_s2"
+                if ("sentinel" in wagl_doc["source_datasets"]["platform_id"].lower())
+                else "dea"
+            ),
         ) as p:
             _apply_wagl_metadata(p, wagl_doc)
 

--- a/tests/integration/h5downsample.py
+++ b/tests/integration/h5downsample.py
@@ -6,6 +6,7 @@ It modifies the file in-place!
 (Intended for creating test datasets where the pixels don't
 matter much but the structure does. The downsampling is dirty.)
 """
+
 import re
 import shutil
 from pathlib import Path

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -449,9 +449,9 @@ def test_filter_folder_structure_info(
     # Our output metadata is in a different place than the data, so we expect it to
     # embed the true location in the metadata (by default)
     if input_dataset_path.is_dir():
-        expected_metadata_doc[
-            "location"
-        ] = f"file://{input_dataset_path.as_posix()}/tileInfo.json"
+        expected_metadata_doc["location"] = (
+            f"file://{input_dataset_path.as_posix()}/tileInfo.json"
+        )
     else:
         expected_metadata_doc["location"] = f"zip:{input_dataset_path}!/"
 

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -4,6 +4,7 @@ Basic tests of DatasetAssembler.
 Some features are testsed in other sibling test files, such as alternative
 naming conventions.
 """
+
 from datetime import datetime, timezone
 from pathlib import Path
 from pprint import pprint

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -111,9 +111,9 @@ def test_minimal_s2_dataset_normal(tmp_path: Path):
         p.datetime = datetime(2018, 11, 4)
         p.product_family = "blueberries"
         p.processed = "2018-11-05T12:23:23"
-        p.properties[
-            "sentinel:sentinel_tile_id"
-        ] = "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
+        p.properties["sentinel:sentinel_tile_id"] = (
+            "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
+        )
 
         dataset_id, metadata_path = p.done()
 
@@ -140,9 +140,9 @@ def test_s2_naming_conventions(tmp_path: Path):
     p.dataset_version = "1.0.0"
     p.region_code = "Oz"
     p.properties["odc:file_format"] = "GeoTIFF"
-    p.properties[
-        "sentinel:sentinel_tile_id"
-    ] = "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
+    p.properties["sentinel:sentinel_tile_id"] = (
+        "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
+    )
 
     p.note_source_datasets(
         "telemetry",


### PR DESCRIPTION
Currently the `dataset_assembler.write_measurements_odc_xarray` method products many deprecation warnings due to the use of `crs.crs_str`:
![image](https://github.com/opendatacube/eo-datasets/assets/17680388/e42ba4a8-7baa-4a16-9a3c-b53cd1f7bd11)

This PR updates the offending line to `str(crs)` instead, as per deprecation warning.