### PR TITLE
Fix lint, and replace black+isort+flake8 with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,27 +4,15 @@ exclude: tests/integration/data
 
 repos:
     # Normalise all Python code. (Black + isort + pyupgrade + autoflake)
-    - repo: https://github.com/Zac-HD/shed
-      rev: 2023.6.1
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.2.1
       hooks:
-      - id: shed
-    - repo: https://github.com/PyCQA/flake8
-      # flake8 version should match .travis.yml
-      rev: 7.0.0
-      hooks:
-          - id: flake8
-            additional_dependencies:
-                  - dlint # Check common security issues
-                  - flake8-broken-line # Don't escape newlines. (surround in parens or simplify)
-                  - flake8-debugger # Don't commit debugger calls
-                  - flake8-executable # Check shebangs and executable permissions
-                  - flake8-logging-format # Use log arguments, not string format
-                  - flake8-pep3101 # Don't use old string % formatting
-                  - flake8-pytest # Use plain assert, not unittest assertions
-                  - pep8-naming # Follow pep8 naming rules (eg. function names lowercase)
+       - id: ruff
+         args: [--fix, --show-fixes, --output-format, grouped]
+       - id: ruff-format
     # Common Python security checks. (this is complementary to dlint in flake8)
     - repo: https://github.com/PyCQA/bandit
-      rev: '1.7.6'
+      rev: '1.7.7'
       hooks:
         - id: bandit
           exclude: '^tests/|_version.py|versioneer.py'

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -10,7 +10,18 @@ from copy import deepcopy
 from enum import Enum, auto
 from pathlib import Path, PosixPath, PurePath
 from textwrap import dedent
-from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 from urllib.parse import urlsplit
 
 import numpy
@@ -147,7 +158,7 @@ class DatasetPrepare(Eo3Interface):
     #:
     #: These are fields that are inherent to the underlying observation, and so will
     #: still be relevant after most 1:1 processing.
-    INHERITABLE_PROPERTIES = {
+    INHERITABLE_PROPERTIES: ClassVar[Set[str]] = {
         "datetime",
         "dtr:end_datetime",
         "dtr:start_datetime",
@@ -453,7 +464,8 @@ class DatasetPrepare(Eo3Interface):
     def __enter__(self) -> "DatasetPrepare":
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb): ...
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        ...
 
     @property
     def collection_location(self) -> Path:

--- a/eodatasets3/documents.py
+++ b/eodatasets3/documents.py
@@ -43,7 +43,7 @@ def is_supported_document_type(path):
     False
     """
     return any(
-        [str(path).lower().endswith(suffix) for suffix in _ALL_SUPPORTED_EXTENSIONS]
+        str(path).lower().endswith(suffix) for suffix in _ALL_SUPPORTED_EXTENSIONS
     )
 
 
@@ -159,9 +159,7 @@ def read_documents(*paths: Path) -> Generator[Tuple[Path, Dict], None, None]:
                 yield path, json.load(f)
             else:
                 raise ValueError(
-                    "Unknown document type for {}; expected one of {!r}.".format(
-                        path.name, _ALL_SUPPORTED_EXTENSIONS
-                    )
+                    f"Unknown document type for {path.name}; expected one of {_ALL_SUPPORTED_EXTENSIONS!r}."
                 )
 
 

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from enum import Enum, auto
 from pathlib import Path, PurePath
 from typing import (
+    ClassVar,
     Dict,
     Generator,
     Iterable,
@@ -563,7 +564,7 @@ class FileWrite:
     This code is derived from the old eugl packaging code and can probably be improved.
     """
 
-    PREDICTOR_DEFAULTS = {
+    PREDICTOR_DEFAULTS: ClassVar[Dict[str, int]] = {
         "int8": 2,
         "uint8": 2,
         "int16": 2,

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Mapping, Optional, Sequence, Set, Union
+from typing import ClassVar, Dict, Mapping, Optional, Sequence, Set, Union
 from urllib.parse import quote, unquote, urlparse
 
 import datacube.utils.uris as dc_uris
@@ -98,7 +98,7 @@ class LazyLabel:
 
 class LazyPlatformAbbreviation:
     # The abbreviations mentioned in DEA naming conventions doc.
-    KNOWN_PLATFORM_ABBREVIATIONS = {
+    KNOWN_PLATFORM_ABBREVIATIONS: ClassVar[Dict[str, str]] = {
         "landsat-5": "ls5",
         "landsat-7": "ls7",
         "landsat-8": "ls8",
@@ -112,7 +112,7 @@ class LazyPlatformAbbreviation:
     }
 
     # If all platform (abbreviations) match a pattern, return this group name instead.
-    KNOWN_PLATFORM_GROUPINGS = {
+    KNOWN_PLATFORM_GROUPINGS: ClassVar[Dict[str, re.Pattern]] = {
         "ls": re.compile(r"ls\d+"),
         "s1": re.compile(r"s1[a-z]+"),
         "s2": re.compile(r"s2[a-z]+"),
@@ -227,7 +227,7 @@ class LazyInstrumentAbbreviation:
 
 
 class LazyProducerAbbreviation:
-    KNOWN_PRODUCER_ABBREVIATIONS = {
+    KNOWN_PRODUCER_ABBREVIATIONS: ClassVar[Dict[str, str]] = {
         "ga.gov.au": "ga",
         "usgs.gov": "usgs",
         "sinergise.com": "sinergise",
@@ -334,7 +334,8 @@ class LazyDatasetLocation:
         return f"{c.collection_prefix}/{offset}/"
 
 
-class MissingRequiredFields(ValueError): ...
+class MissingRequiredFieldsError(ValueError):
+    ...
 
 
 class RequiredPropertyDict(Eo3Dict):
@@ -349,7 +350,7 @@ class RequiredPropertyDict(Eo3Dict):
     """
 
     # Displayed to user for friendlier errors.
-    _REQUIRED_PROPERTY_HINTS = {
+    _REQUIRED_PROPERTY_HINTS: ClassVar[Dict[str, str]] = {
         "odc:product_family": 'eg. "wofs" or "level1"',
         "odc:processing_datetime": "Time of processing, perhaps datetime.utcnow()?",
         "odc:producer": "Creator of data, eg 'usgs.gov' or 'ga.gov.au'",
@@ -391,7 +392,7 @@ class RequiredPropertyDict(Eo3Dict):
                     hint = f" ({hint})"
                 examples.append(f"\n- {p!r}{hint}")
 
-            raise MissingRequiredFields(
+            raise MissingRequiredFieldsError(
                 f"Need more properties to fulfill naming conventions."
                 f"{''.join(examples)}"
             )
@@ -541,7 +542,7 @@ class NamingConventions:
 
     """
 
-    _ABSOLUTE_MINIMAL_PROPERTIES = {
+    _ABSOLUTE_MINIMAL_PROPERTIES: ClassVar[Set[str]] = {
         "odc:product_family",
         # Required by Stac regardless.
         "datetime",

--- a/eodatasets3/prepare/landsat_l1_prepare.py
+++ b/eodatasets3/prepare/landsat_l1_prepare.py
@@ -262,7 +262,7 @@ def get_mtl_content(acquisition_path: Path, root_element=None) -> Tuple[Dict, st
                         mtl_doc, file_root_element = read_mtl(fp)
                         return mtl_doc, file_root_element, member.name
             else:
-                raise RuntimeError(f"MTL file not found in {str(acquisition_path)}")
+                raise RuntimeError(f"MTL file not found in {acquisition_path!s}")
 
     else:
         paths = list(acquisition_path.rglob("*_MTL.txt"))
@@ -318,7 +318,7 @@ def read_mtl(fp: Iterable[Union[str, bytes]], root_element=None) -> Tuple[Dict, 
 
     tree = _parse_group(fp)
     if root_element is None:
-        root_element = list(tree.keys())[0]
+        root_element = next(iter(tree.keys()))
     return tree[root_element], root_element
 
 
@@ -493,8 +493,7 @@ def prepare_and_write(
                     usgs_file_type.startswith("band_")
                     and (
                         # The older collection called quality a "band"
-                        "quality"
-                        not in usgs_file_type
+                        "quality" not in usgs_file_type
                     )
                 ),
             )

--- a/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
+++ b/eodatasets3/prepare/nasa_c_m_mcd43a1_6_prepare.py
@@ -36,20 +36,20 @@ def parse_xml(filepath: Path):
     end_date = root.find("*//RangeDateTime/RangeEndingDate").text
     end_time = root.find("*//RangeDateTime/RangeEndingTime").text
     v_tile = (
-        [
+        next(
             ele
             for ele in root.findall("*//PSA")
             if ele.find("PSAName").text == "VERTICALTILENUMBER"
-        ][0]
+        )
         .find("PSAValue")
         .text
     )
     h_tile = (
-        [
+        next(
             ele
             for ele in root.findall("*//PSA")
             if ele.find("PSAName").text == "HORIZONTALTILENUMBER"
-        ][0]
+        )
         .find("PSAValue")
         .text
     )

--- a/eodatasets3/prepare/s2_common.py
+++ b/eodatasets3/prepare/s2_common.py
@@ -150,7 +150,10 @@ class RegionLookup:
 
         def vals(path: Path):
             i = FolderInfo.for_path(path)
-            return i.area_tuple + (i.region_code,)
+            return (
+                *i.area_tuple,
+                i.region_code,
+            )
 
         res = s.executemany(
             "insert into regions values (?,?,?,?,?) on conflict do nothing",

--- a/eodatasets3/prepare/sentinel_l1_prepare.py
+++ b/eodatasets3/prepare/sentinel_l1_prepare.py
@@ -899,8 +899,7 @@ def main(
 
                     if always_granule_id or (
                         # None means 'auto': ie. automatically include granule id when there are multiple granules
-                        always_granule_id is None
-                        and len(granule_offsets) > 1
+                        always_granule_id is None and len(granule_offsets) > 1
                     ):
                         yaml_filename = (
                             f"{found_dataset.name}.{granule_offset}.odc-metadata.yaml"

--- a/eodatasets3/scripts/recompress.py
+++ b/eodatasets3/scripts/recompress.py
@@ -318,7 +318,7 @@ def _recompress_image(
     if len(input_image.indexes) != 1:
         raise ValueError(
             f"Expecting one-band-per-tif input (USGS packages). "
-            f"Input has multiple layers {repr(input_image.indexes)}"
+            f"Input has multiple layers {input_image.indexes!r}"
         )
 
     array: numpy.ndarray = input_image.read(1)
@@ -415,7 +415,7 @@ def main(
                 )
             else:
                 raise ValueError(
-                    f"Expected either tar.gz or a dataset folder. " f"Got: {repr(path)}"
+                    f"Expected either tar.gz or a dataset folder. " f"Got: {path!r}"
                 )
 
             if not success:

--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -461,8 +461,8 @@ class ClickDatetime(click.ParamType):
         except ValueError:
             self.fail(
                 (
-                    "Invalid date string {!r}. Expected any ISO date/time format "
-                    '(eg. "2017-04-03" or "2014-05-14 12:34")'.format(value)
+                    f"Invalid date string {value!r}. Expected any ISO date/time format "
+                    '(eg. "2017-04-03" or "2014-05-14 12:34")'
                 ),
                 param,
                 ctx,

--- a/eodatasets3/utils.py
+++ b/eodatasets3/utils.py
@@ -39,8 +39,8 @@ class ClickDatetime(click.ParamType):
         except ValueError:
             self.fail(
                 (
-                    "Invalid date string {!r}. Expected any ISO date/time format "
-                    '(eg. "2017-04-03" or "2014-05-14 12:34")'.format(value)
+                    f"Invalid date string {value!r}. Expected any ISO date/time format "
+                    '(eg. "2017-04-03" or "2014-05-14 12:34")'
                 ),
                 param,
                 ctx,

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -544,7 +544,7 @@ def validate_product(doc: Dict) -> ValidationMessages:
                 if measurements_with_this_name:
                     seen_in = " and ".join(
                         repr(s)
-                        for s in ([measurement_name] + measurements_with_this_name)
+                        for s in ([measurement_name, *measurements_with_this_name])
                     )
 
                     # If the same name is used by different measurements, its a hard error.

--- a/eodatasets3/verify.py
+++ b/eodatasets3/verify.py
@@ -187,9 +187,7 @@ class PackageChecksum:
         with output_file.open("wb") as f:
             f.writelines(
                 (
-                    "{}\t{}\n".format(
-                        str(hash_), str(filename.relative_to(output_file.parent))
-                    ).encode("utf-8")
+                    f"{hash_!s}\t{filename.relative_to(output_file.parent)!s}\n".encode()
                     for filename, hash_ in sorted(self._file_hashes.items())
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,45 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 
+[tool.ruff]
+
+target-version = "py38"
+
+
+[tool.ruff.lint]
+# Which checkers to enable?
+select = [
+    "A",  # Don't shadow built-ins
+    "C4",  # Use list comprehensions etc
+    "E",  # pycodestyle
+    "EXE",  # Shebangs+Executable permisssions should match
+    "F",  # pyflakes
+    "G",  # Use logging formatter, not manual string concat
+    "I",  # Auto-sort imports
+    "ICN",  # Use standard import names, like np for numpy
+    "N",  # pep8-naming
+    "NPY",  # Numpy
+    "RUF",  # Ruf-specific python rules
+    # We're using a separate pre-commit hook for this.
+    # "S",  # Bandit (security)
+    "UP"  # pyupgrade
+]
+
+ignore = [
+    # Disable these as we don't want to change old code unnecessarily.
+    "RUF013", # PEP 484 prohibits implicit `Optional`
+    "C408", # Unnecessary `dict` call (rewrite as a literal)
+    "ICN001", #  `numpy` should be imported as `np`
+    "N818", # Exception name should be named with an Error suffix
+]
+
+# Matching old behaviour: We auto-format with the smaller line default
+# ...  but only enforce line length to be under this larger 120 limit.
+pycodestyle.max-line-length = 120
+
+[tool.ruff.per-file-ignores]
+"docs/conf.py" = ["A001"] # Variable `copyright` shadowing a Python builtin (needed for api)
+
 [tool.black]
 line-length = 88
 target_version = ['py36', 'py37', 'py38']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,9 +64,9 @@ def assert_file_structure(folder, expected_structure, root=""):
 
     if required_filenames != (actual_filenames - optional_filenames):
         missing_files = required_filenames - actual_filenames
-        missing_text = "Missing: %r" % sorted(list(missing_files))
+        missing_text = "Missing: %r" % sorted(missing_files)
         extra_files = actual_filenames - required_filenames
-        added_text = "Extra  : %r" % sorted(list(extra_files))
+        added_text = "Extra  : %r" % sorted(extra_files)
         raise AssertionError(
             f"Folder mismatch of {root!r}\n\t{missing_text}\n\t{added_text}"
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -51,7 +51,7 @@ def assert_expected_eo3_path(
         expected_doc,
         expected_path,
         # We check the geometry below
-        ignore_fields=("geometry",) + tuple(ignore_fields),
+        ignore_fields=("geometry", *ignore_fields),
     )
 
     if "geometry" not in ignore_fields:
@@ -93,7 +93,7 @@ def assert_expected_eo3(
         )
     e = serialise.to_doc(expected_doc)
     g = serialise.to_doc(given_doc)
-    for f in ("geometry",) + ignore_fields:
+    for f in ("geometry", *ignore_fields):
         e.pop(f)
         g.pop(f)
     assert_same(g, e)
@@ -197,12 +197,12 @@ def format_doc_diffs(left: Dict, right: Dict) -> Iterable[str]:
         out.append("Added fields:")
         for offset in doc_diffs.tree["dictionary_item_added"].items:
             offset: DiffLevel
-            out.append(f"    {clean_offset(offset.path())} = {repr(offset.t2)}")
+            out.append(f"    {clean_offset(offset.path())} = {offset.t2!r}")
     if "dictionary_item_removed" in doc_diffs:
         out.append("Removed fields:")
         for offset in doc_diffs.tree["dictionary_item_removed"].items:
             offset: DiffLevel
-            out.append(f"    {clean_offset(offset.path())} = {repr(offset.t1)}")
+            out.append(f"    {clean_offset(offset.path())} = {offset.t1!r}")
     # Anything we missed from the (sometimes changing) diff api?
     if len(out) == 1:
         out.append(repr(doc_diffs))

--- a/tests/integration/prepare/test_esri_land_cover.py
+++ b/tests/integration/prepare/test_esri_land_cover.py
@@ -8,7 +8,6 @@ from shapely.geometry import shape
 from eodatasets3 import DatasetDoc, Eo3Dict
 from eodatasets3.model import GridDoc, MeasurementDoc, ProductDoc
 from eodatasets3.prepare.esri_land_cover_prepare import as_eo3
-
 from tests.common import assert_expected_eo3
 
 ESRI_ANTIMERIDIAN_OVERLAP_TIF: Path = (

--- a/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
+++ b/tests/integration/prepare/test_noaa_c_c_prwtreatm_1.py
@@ -7,7 +7,6 @@ from deepdiff import DeepDiff
 
 from eodatasets3 import serialise
 from eodatasets3.prepare import noaa_c_c_prwtreatm_1_prepare
-
 from tests.common import assert_shapes_mostly_equal, run_prepare_cli
 
 NCEP_PR_WTR_FILE: Path = (

--- a/tests/integration/prepare/test_prepare_landsat_l1.py
+++ b/tests/integration/prepare/test_prepare_landsat_l1.py
@@ -6,7 +6,6 @@ from typing import Callable, Dict
 import pytest
 
 from eodatasets3.prepare import landsat_l1_prepare
-
 from tests.common import check_prepare_outputs, run_prepare_cli
 
 LC08_L2_C2_POST_20210507_INPUT_PATH: Path = (
@@ -857,7 +856,7 @@ def expected_lt05_l2_c2_folder():
             "eo:sun_elevation": 41.583_263_99,
             "landsat:algorithm_source_surface_reflectance": "LEDAPS_3.4.0",
             "landsat:collection_category": "T1",
-            "landsat:collection_number": int(2),
+            "landsat:collection_number": 2,
             "landsat:data_type": "L2SP",
             "landsat:geometric_rmse_model_x": 3.085,
             "landsat:geometric_rmse_model_y": 2.977,
@@ -983,7 +982,7 @@ def expected_le07_l2_c2_folder():
             "eo:sun_elevation": 31.970_873_9,
             "landsat:algorithm_source_surface_reflectance": "LEDAPS_3.4.0",
             "landsat:collection_category": "T1",
-            "landsat:collection_number": int(2),
+            "landsat:collection_number": 2,
             "landsat:data_type": "L2SP",
             "landsat:geometric_rmse_model_x": 3.08,
             "landsat:geometric_rmse_model_y": 3.663,

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -9,7 +9,6 @@ import pytest
 from eodatasets3.prepare import sentinel_l1_prepare
 from eodatasets3.prepare.s2_common import RegionLookup
 from eodatasets3.prepare.sentinel_l1_prepare import FolderInfo
-
 from tests.common import (
     assert_expected_eo3_path,
     check_prepare_outputs,
@@ -449,9 +448,9 @@ def test_filter_folder_structure_info(
     # Our output metadata is in a different place than the data, so we expect it to
     # embed the true location in the metadata (by default)
     if input_dataset_path.is_dir():
-        expected_metadata_doc["location"] = (
-            f"file://{input_dataset_path.as_posix()}/tileInfo.json"
-        )
+        expected_metadata_doc[
+            "location"
+        ] = f"file://{input_dataset_path.as_posix()}/tileInfo.json"
     else:
         expected_metadata_doc["location"] = f"zip:{input_dataset_path}!/"
 

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -18,7 +18,6 @@ from ruamel import yaml
 from eodatasets3 import DatasetAssembler, DatasetPrepare, namer, serialise
 from eodatasets3.images import GridSpec
 from eodatasets3.model import DatasetDoc
-
 from tests import assert_file_structure
 from tests.common import assert_expected_eo3_path, assert_same
 
@@ -497,7 +496,7 @@ def test_add_source_dataset(tmp_path: Path, inherit_geom):
         / "data/wofs/ga_ls_wofs_3_099081_2020-07-26_interim_water_clipped.tif",
     )
 
-    id, path = p.done()
+    dataset_uuid, path = p.done()
 
     output = serialise.from_path(path)
     if inherit_geom:

--- a/tests/integration/test_image.py
+++ b/tests/integration/test_image.py
@@ -151,7 +151,7 @@ def test_calc_range():
 
     assert np.array_equal(expected_combined_mask, mask), (
         f"Combined mask isn't as expected. "
-        f"Diff: {repr(np.logical_xor(expected_combined_mask, mask))}"
+        f"Diff: {np.logical_xor(expected_combined_mask, mask)!r}"
     )
 
     assert calculated_range == (

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -8,7 +8,6 @@ import pytest
 from ruamel import yaml
 
 from eodatasets3 import DatasetAssembler, DatasetDoc, namer
-
 from tests.common import assert_expected_eo3_path
 
 
@@ -111,9 +110,9 @@ def test_minimal_s2_dataset_normal(tmp_path: Path):
         p.datetime = datetime(2018, 11, 4)
         p.product_family = "blueberries"
         p.processed = "2018-11-05T12:23:23"
-        p.properties["sentinel:sentinel_tile_id"] = (
-            "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
-        )
+        p.properties[
+            "sentinel:sentinel_tile_id"
+        ] = "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
 
         dataset_id, metadata_path = p.done()
 
@@ -140,9 +139,9 @@ def test_s2_naming_conventions(tmp_path: Path):
     p.dataset_version = "1.0.0"
     p.region_code = "Oz"
     p.properties["odc:file_format"] = "GeoTIFF"
-    p.properties["sentinel:sentinel_tile_id"] = (
-        "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
-    )
+    p.properties[
+        "sentinel:sentinel_tile_id"
+    ] = "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05"
 
     p.note_source_datasets(
         "telemetry",

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -14,10 +14,10 @@ from rio_cogeo import cogeo
 
 import eodatasets3
 from eodatasets3.model import DatasetDoc
-
-from . import assert_image
 from tests import assert_file_structure
 from tests.common import assert_expected_eo3_path, assert_same_as_file
+
+from . import assert_image
 
 h5py = pytest.importorskip(
     "h5py",

--- a/tests/integration/test_recompress.py
+++ b/tests/integration/test_recompress.py
@@ -135,9 +135,9 @@ def test_recompress_gap_mask_dataset(tmp_path: Path):
     # Pytest has better error messages for strings than Paths.
     all_output_files = [str(p) for p in output_base.rglob("*") if p.is_file()]
 
-    assert (
-        len(all_output_files) == 1
-    ), "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    assert len(all_output_files) == 1, (
+        "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    )
     assert all_output_files == [str(expected_output)]
 
     assert (
@@ -218,9 +218,9 @@ def test_recompress_dirty_dataset(tmp_path: Path):
     # Pytest has better error messages for strings than Paths.
     all_output_files = [str(p) for p in output_base.rglob("*") if p.is_file()]
 
-    assert (
-        len(all_output_files) == 1
-    ), "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    assert len(all_output_files) == 1, (
+        "Expected one output tar file. Got: \n\t" + "\n\t".join(all_output_files)
+    )
     assert all_output_files == [str(expected_output)]
 
     assert (

--- a/tests/integration/test_serialise.py
+++ b/tests/integration/test_serialise.py
@@ -5,7 +5,6 @@ import ciso8601
 
 from eodatasets3 import serialise
 from eodatasets3.utils import default_utc
-
 from tests.common import dump_roundtrip
 
 

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -7,7 +7,6 @@ import pytest
 
 from eodatasets3 import serialise
 from eodatasets3.scripts import tostac
-
 from tests.common import assert_same, run_prepare_cli
 
 TO_STAC_DATA: Path = Path(__file__).parent.joinpath("data/tostac")
@@ -77,10 +76,10 @@ def remove_stac_properties(doc: Dict, remove_properties=()):
     Remove the given fields from properties and assets.
     """
 
-    def remove_proj(dict: Dict):
-        for key in list(dict.keys()):
+    def remove_proj(d: Dict):
+        for key in list(d.keys()):
             if key in remove_properties:
-                del dict[key]
+                del d[key]
 
     remove_proj(doc["properties"])
     for name, asset in doc["assets"].items():

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -223,8 +223,8 @@ class ValidateRunner:
         ), f"Expected validation to fail.\n{self.result.output}"
 
         if codes is not None:
-            assert sorted(codes) == sorted(
-                self.messages.keys()
+            assert (
+                sorted(codes) == sorted(self.messages.keys())
             ), f"{sorted(codes)} != {sorted(self.messages.keys())}. Messages: {self.messages}"
         else:
             assert (

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -3,7 +3,6 @@ Module
 """
 
 from eodatasets3.documents import _find_any_metadata_suffix, find_metadata_path
-
 from tests import write_files
 
 

--- a/tests/test_serialise.py
+++ b/tests/test_serialise.py
@@ -6,7 +6,7 @@ from eodatasets3 import serialise
 def test_dumps_yaml_scientific_notation():
     stream = StringIO()
     serialise.dumps_yaml(stream, {"response": [7e-06, 7e-06, 8e-06]})
-    assert type(stream.getvalue()) == str
+    assert isinstance(stream.getvalue(), str)
     assert stream.getvalue().split()[3] == "7.e-06"
     assert stream.getvalue().split()[5] == "7.e-06"
     assert stream.getvalue().split()[7] == "8.e-06"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,12 +3,11 @@ import unittest
 from textwrap import dedent
 
 from eodatasets3 import verify
-
 from tests import write_files
 
 
 class VerifyTests(unittest.TestCase):
-    def test_checksum(self):  # noqa: T003
+    def test_checksum(self):
         d = write_files({"test1.txt": "test"})
 
         test_file = d.joinpath("test1.txt")

--- a/versioneer.py
+++ b/versioneer.py
@@ -427,9 +427,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
     return stdout, p.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
The lint build didn't seem to be fully frozen, as it has started failing in develop.

We'll go ahead and replace the hybrid set of linting tools with [Ruff](https://github.com/astral-sh/ruff).

Ruff seems well made, fast, and we've used it successfully in our other repos.

Includes other general clean-up.