### PR TITLE
Use existing nodata attributes if they exist on `xarray.DataArrays`

### DIFF
--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1365,7 +1365,7 @@ class DatasetAssembler(DatasetPrepare):
         The main requirement is that the Dataset contains a CRS attribute
         and X/Y or lat/long dimensions and coordinates. These are used to
         create an ODC GeoBox.
-        
+
         Nodata values will be taken from the ".nodata" attribute on each
         individual array if it exists and no custom nodata value is provided.
 
@@ -1378,9 +1378,11 @@ class DatasetAssembler(DatasetPrepare):
         for name, dataarray in dataset.data_vars.items():
             name: str
 
-            # Get nodata attribute from array if nodata is not provided 
+            # Get nodata attribute from array if nodata is not provided
             # and attribute is not None
-            nodata_value = dataarray.attrs.get('nodata', None) if nodata is None else nodata
+            nodata_value = (
+                dataarray.attrs.get("nodata", None) if nodata is None else nodata
+            )
 
             self._write_measurement(
                 name,

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1365,6 +1365,9 @@ class DatasetAssembler(DatasetPrepare):
         The main requirement is that the Dataset contains a CRS attribute
         and X/Y or lat/long dimensions and coordinates. These are used to
         create an ODC GeoBox.
+        
+        Nodata values will be taken from the ".nodata" attribute on each
+        individual array if it exists and no custom nodata value is provided.
 
         :param xarray.Dataset dataset: an xarray dataset (as returned by
                 :meth:`datacube.Datacube.load` and other methods)
@@ -1374,6 +1377,11 @@ class DatasetAssembler(DatasetPrepare):
         grid_spec = images.GridSpec.from_odc_xarray(dataset)
         for name, dataarray in dataset.data_vars.items():
             name: str
+
+            # Get nodata attribute from array if nodata is not provided 
+            # and attribute is not None
+            nodata_value = dataarray.attrs.get('nodata', None) if nodata is None else nodata
+
             self._write_measurement(
                 name,
                 dataarray.data,
@@ -1385,7 +1393,7 @@ class DatasetAssembler(DatasetPrepare):
                 expand_valid_data=expand_valid_data,
                 overview_resampling=overview_resampling,
                 overviews=overviews,
-                nodata=nodata,
+                nodata=nodata_value,
             )
 
     def _write_measurement(


### PR DESCRIPTION
Currently the `write_measurements_odc_xarray()` method requires you to set a single data value to all `xr.DataArrays` in the input `xr.Dataset`. However, individual variables in a dataset often have their own nodata values, as specified in their ODC `.nodata` attribute. 

This PR updates `write_measurements_odc_xarray()` to use the nodata value in the `.nodata` attribute if it exists (and if no custom nodata value is manually provided via the `nodata` param).

Have tested this locally and it works well.