### PR TITLE
Fix missing readthedocs sections

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,3 @@
----
 # .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
@@ -7,6 +6,11 @@
 version: 2
 
 # Build documentation in the docs/ directory with Sphinx
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 sphinx:
   configuration: docs/conf.py
 
@@ -14,6 +18,5 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Half of the API section of the docs is missing in the current public docs, causing many sections of the docs to not have links to important information.

The build seemed to have failed entirely some time recently too.

You can see a test build result from my branch here: https://jez-eod3.readthedocs.io/en/latest/
