### PR TITLE
Explicitly use the modern `sphinx_rtd_theme` doc theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,11 +58,4 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # overwrite the builtin "default.css".
 # html_static_path = ["_static"]
 
-
-if is_on_readthedocs:
-    html_theme = "default"
-else:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 .
 sphinx-autodoc-typehints
+sphinx-rtd-theme


### PR DESCRIPTION
[The docs](https://eodatasets.readthedocs.io/en/latest/) have reverted to a very old theme (I don't know why... did the default change?).

Explicitly set the modern rtd theme.

A demo build of this change is here: https://jez-eod3.readthedocs.io/en/latest/
