### PR TITLE
Integrate COG writing logic from odc-geo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -192,13 +192,13 @@ We can record them as source datasets, and the assembler can optionally copy any
 
 
 In these situations, we often write our new pixels as a numpy array, inheriting the existing
-:class:`grid spatial information <eodatasets3.GridSpec>` of our input dataset::
+:class:`grid spatial information <odc.geo.geobox.GeoBox>` of our input dataset::
 
-      # Write a measurement from a numpy array, using the source dataset's grid spec.
+      # Write a measurement from a numpy array, using the source dataset's geobox.
       p.write_measurement_numpy(
          "water",
          my_computed_numpy_array,
-         GridSpec.from_dataset_doc(source_dataset),
+         images.gbox_from_dataset_doc(source_dataset),
          nodata=-999,
       )
 
@@ -218,15 +218,15 @@ in the document will be relative to this location:
 
 .. testsetup:: inmem
 
-   from eodatasets3 import GridSpec
+   from odc.geo.geobox import GeoBox
 
    import tempfile
 
    tmp_path = Path(tempfile.mkdtemp())
 
-   grid_spec = GridSpec(shape=(7721, 7621),
-      transform=Affine(30.0, 0.0, 241485.0, 0.0, -30.0, -2281485.0),
-      crs=CRS.from_epsg(32656)
+   geobox = GeoBox(shape=(7721, 7621),
+      affine=Affine(30.0, 0.0, 241485.0, 0.0, -30.0, -2281485.0),
+      crs=32656
    )
 
    dataset_location = (tmp_path / 'test_dataset')
@@ -243,16 +243,16 @@ in the document will be relative to this location:
 
 
 Normally when a measurement is added, the image will be opened to read
-grid and size informaation. You can avoid this by giving a :class:`GridSpec <eodatasets3.GridSpec>`
-yourself (see :class:`GridSpec doc <eodatasets3.GridSpec>` for creation):
+grid and size informaation. You can avoid this by giving a :class:`GeoBox <odc.geo.geobox.GeoBox>`
+yourself (see :class:`GeoBox doc <odc.geo.geobox.GeoBox>` for creation):
 
 .. doctest:: inmem
 
    >>> p.note_measurement(
    ...     "blue",
    ...     measurement_path,
-   ...     # We give it grid information, so it doesn't have to read it itself.
-   ...     grid=grid_spec,
+   ...     # We give it geobox information, so it doesn't have to read it itself.
+   ...     geobox=geobox,
    ...     # And the image pixels, since we are letting it calculate our geometry.
    ...     pixels=numpy.ones((60, 60), numpy.int16),
    ...     nodata=-1,

--- a/eodatasets3/__init__.py
+++ b/eodatasets3/__init__.py
@@ -1,7 +1,7 @@
 from . import _version
 from ._version import get_versions
 from .assemble import DatasetAssembler, DatasetPrepare, IfExists, IncompleteDatasetError
-from .images import GridSpec, ValidDataMethod
+from .images import ValidDataMethod
 from .model import DatasetDoc
 from .names import NamingConventions, namer
 from .properties import Eo3Dict
@@ -16,7 +16,6 @@ __all__ = (
     "DatasetDoc",
     "DatasetPrepare",
     "Eo3Dict",
-    "GridSpec",
     "IfExists",
     "IncompleteDatasetError",
     "NamingConventions",

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1296,7 +1296,7 @@ class DatasetAssembler(DatasetPrepare):
             name,
             ds.read(index or 1),
             GeoBox(
-                ds.shape, ds.transform, str(ds.crs)
+                ds.shape, ds.transform, ds.crs
             ),  # GeoBox.from_rio changes the crs format
             self._work_path
             / (path or self.names.measurement_filename(name, "tif", file_id=file_id)),

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1295,9 +1295,7 @@ class DatasetAssembler(DatasetPrepare):
         self._write_measurement(
             name,
             ds.read(index or 1),
-            GeoBox(
-                ds.shape, ds.transform, ds.crs
-            ),  # GeoBox.from_rio changes the crs format
+            GeoBox.from_rio(ds),
             self._work_path
             / (path or self.names.measurement_filename(name, "tif", file_id=file_id)),
             expand_valid_data=expand_valid_data,

--- a/eodatasets3/assemble.py
+++ b/eodatasets3/assemble.py
@@ -1411,6 +1411,10 @@ class DatasetAssembler(DatasetPrepare):
     ):
         _validate_property_name(name)
 
+        # convert any bools to uin8
+        if data.dtype.name == "bool":
+            data = numpy.uint8(data)
+
         _write_cog(
             data,
             geobox=geobox,

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -238,7 +238,7 @@ class MeasurementBundler:
                     f"Duplicate addition of band called {name!r}. "
                     f"Original at {measurements[name]} and now {path}"
                 )
-        if grid.crs.epsg is not None:
+        if grid.crs and grid.crs.epsg is not None:
             grid = GeoBox(grid.shape, grid.affine, grid.crs.epsg)
         self._measurements_per_grid[grid][name] = _MeasurementLocation(path, layer)
         if expand_valid_data:

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -305,7 +305,7 @@ class MeasurementBundler:
         # Otherwise, try resolution names:
         named_grids = {"default": default_grid}
         for grid, measurements in grids_by_frequency:
-            res_y, res_x = grid.resolution_yx
+            res_y, res_x = grid.resolution.map(abs).yx
             if res_x > 1:
                 res_x = int(res_x)
             grid_name = f"{res_x}"

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -238,7 +238,7 @@ class MeasurementBundler:
                     f"Duplicate addition of band called {name!r}. "
                     f"Original at {measurements[name]} and now {path}"
                 )
-
+        grid = GeoBox(grid.shape, grid.affine, grid.crs.to_wkt())
         self._measurements_per_grid[grid][name] = _MeasurementLocation(path, layer)
         if expand_valid_data:
             self._expand_valid_data_mask(grid, img, nodata)

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -238,7 +238,8 @@ class MeasurementBundler:
                     f"Duplicate addition of band called {name!r}. "
                     f"Original at {measurements[name]} and now {path}"
                 )
-        grid = GeoBox(grid.shape, grid.affine, grid.crs.to_wkt())
+        if grid.crs.epsg is not None:
+            grid = GeoBox(grid.shape, grid.affine, grid.crs.epsg)
         self._measurements_per_grid[grid][name] = _MeasurementLocation(path, layer)
         if expand_valid_data:
             self._expand_valid_data_mask(grid, img, nodata)
@@ -358,7 +359,7 @@ class MeasurementBundler:
                     f"\t{grid.crs.to_string()!r}\n"
                 )
 
-            grid_docs[grid_name] = GridDoc(grid.shape.wh, grid.transform)
+            grid_docs[grid_name] = GridDoc(grid.shape.yx, grid.transform)
 
             for measurement_name, measurement_path in measurements.items():
                 # No measurement groups in the doc: we replace with underscores.

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -7,9 +7,6 @@ from collections import defaultdict
 from collections.abc import Generator, Iterable, Sequence
 from enum import Enum, auto
 from pathlib import Path, PurePath
-from typing import (
-    ClassVar,
-)
 
 import attr
 import numpy
@@ -18,28 +15,19 @@ import rasterio.features
 import shapely
 import shapely.affinity
 import shapely.ops
-import xarray
-from affine import Affine
+from odc.geo import CRS
+from odc.geo.geobox import GeoBox
 from rasterio import DatasetReader
-from rasterio.coords import BoundingBox
-from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.io import DatasetWriter, MemoryFile
-from rasterio.shutil import copy as rio_copy
 from rasterio.warp import calculate_default_transform, reproject
 from scipy.ndimage import binary_fill_holes
 from shapely.geometry import box
 from shapely.geometry.base import CAP_STYLE, JOIN_STYLE, BaseGeometry
 
 from eodatasets3.model import DatasetDoc, GridDoc, MeasurementDoc
-from eodatasets3.properties import FileFormat
 
 DEFAULT_OVERVIEWS = (8, 16, 32)
-
-try:
-    import h5py
-except ImportError:
-    h5py = None
 
 
 class ValidDataMethod(Enum):
@@ -74,89 +62,21 @@ class ValidDataMethod(Enum):
     bounds = auto()
 
 
-@attr.s(auto_attribs=True, slots=True, hash=True, frozen=True)
-class GridSpec:
+def gbox_from_path(path: str) -> GeoBox:
+    """Create from the spec of a (rio-readable) filesystem path or url"""
+    with rasterio.open(path) as rio:
+        return GeoBox.from_rio(rio)
+
+
+def gbox_from_dataset_doc(ds: DatasetDoc, grid="default") -> GeoBox:
     """
-    The grid spec defines the coordinates/transform and size of pixels of a
-    measurment.
+    Create from an existing parsed metadata document
 
-    The easiest way to create one is use the ``GridSpec.from_*()`` class methods, such as
-    ``GridSpec.from_path(my_image_path)``.
-
-    To create one manually:
-
-    >>> from eodatasets3 import GridSpec
-    >>> from affine import Affine
-    >>> from rasterio.crs import CRS
-    >>> g = GridSpec(shape=(7721, 7621),
-    ...              transform=Affine(30.0, 0.0, 241485.0, 0.0, -30.0, -2281485.0),
-    ...              crs=CRS.from_epsg(32656))
-    >>> # Numbers copied from equivalent rio dataset.bounds call.
-    >>> g.bounds
-    BoundingBox(left=241485.0, bottom=-2513115.0, right=470115.0, top=-2281485.0)
-    >>> g.resolution_yx
-    (30.0, 30.0)
+    :param grid: Grid name to read, if not the default.
     """
+    g = ds.grids[grid]
 
-    #:
-    shape: tuple[int, int]
-    #:
-    transform: Affine
-    #:
-    crs: CRS = attr.ib(
-        metadata=dict(doc_exclude=True), default=None, hash=False, eq=False
-    )
-
-    @classmethod
-    def from_dataset_doc(cls, ds: DatasetDoc, grid="default") -> "GridSpec":
-        """
-        Create from an existing parsed metadata document
-
-        :param grid: Grid name to read, if not the default.
-        """
-        g = ds.grids[grid]
-
-        if ds.crs.startswith("epsg:"):
-            crs = CRS.from_epsg(ds.crs[5:])
-        else:
-            crs = CRS.from_wkt(ds.crs)
-
-        return GridSpec(g.shape, g.transform, crs=crs)
-
-    @classmethod
-    def from_rio(cls, dataset: rasterio.DatasetReader) -> "GridSpec":
-        """Create from an open rasterio dataset"""
-        return cls(shape=dataset.shape, transform=dataset.transform, crs=dataset.crs)
-
-    @property
-    def resolution_yx(self):
-        return abs(self.transform[4]), abs(self.transform[0])
-
-    @classmethod
-    def from_odc_xarray(cls, dataset: xarray.Dataset) -> "GridSpec":
-        """Create from an ODC xarray"""
-        shape = {v.shape for v in dataset.data_vars.values()}.pop()
-        return cls(
-            shape=shape,
-            transform=dataset.geobox.transform,
-            crs=CRS.from_wkt(str(dataset.geobox.crs)),
-        )
-
-    @classmethod
-    def from_path(cls, path: str) -> "GridSpec":
-        """Create from the spec of a (rio-readable) filesystem path or url"""
-        with rasterio.open(path) as rio:
-            return GridSpec.from_rio(rio)
-
-    @property
-    def bounds(self):
-        """
-        Get bounding box.
-        """
-        return BoundingBox(
-            *(self.transform * (0, self.shape[0]))
-            + (self.transform * (self.shape[1], 0))
-        )
+    return GeoBox(g.shape, g.transform, crs=ds.crs)
 
 
 def generate_tiles(
@@ -298,14 +218,14 @@ class MeasurementBundler:
     def __init__(self):
         # The measurements grouped by their grid.
         # (value is band_name->Path)
-        self._measurements_per_grid: dict[GridSpec, _Measurements] = defaultdict(dict)
+        self._measurements_per_grid: dict[GeoBox, _Measurements] = defaultdict(dict)
         # Valid data mask per grid, in pixel coordinates.
-        self.mask_by_grid: dict[GridSpec, numpy.ndarray] = {}
+        self.mask_by_grid: dict[GeoBox, numpy.ndarray] = {}
 
     def record_image(
         self,
         name: str,
-        grid: GridSpec,
+        grid: GeoBox,
         path: PurePath | str,
         img: numpy.ndarray,
         layer: str | None = None,
@@ -324,7 +244,7 @@ class MeasurementBundler:
             self._expand_valid_data_mask(grid, img, nodata)
 
     def _expand_valid_data_mask(
-        self, grid: GridSpec, img: numpy.ndarray, nodata: float | int
+        self, grid: GeoBox, img: numpy.ndarray, nodata: float | int
     ):
         if nodata is None:
             nodata = float("nan") if numpy.issubdtype(img.dtype, numpy.floating) else 0
@@ -341,13 +261,13 @@ class MeasurementBundler:
             mask |= valid_values
         self.mask_by_grid[grid] = mask
 
-    def _as_named_grids(self) -> dict[str, tuple[GridSpec, _Measurements]]:
+    def _as_named_grids(self) -> dict[str, tuple[GeoBox, _Measurements]]:
         """Get our grids with sensible (hopefully!), names."""
 
         # Order grids from most to fewest measurements.
         # PyCharm's typing seems to get confused by the sorted() call.
         # noinspection PyTypeChecker
-        grids_by_frequency: list[tuple[GridSpec, _Measurements]] = sorted(
+        grids_by_frequency: list[tuple[GeoBox, _Measurements]] = sorted(
             self._measurements_per_grid.items(), key=lambda k: len(k[1]), reverse=True
         )
 
@@ -438,7 +358,7 @@ class MeasurementBundler:
                     f"\t{grid.crs.to_string()!r}\n"
                 )
 
-            grid_docs[grid_name] = GridDoc(grid.shape, grid.transform)
+            grid_docs[grid_name] = GridDoc(grid.shape.wh, grid.transform)
 
             for measurement_name, measurement_path in measurements.items():
                 # No measurement groups in the doc: we replace with underscores.
@@ -468,7 +388,7 @@ class MeasurementBundler:
             grid, mask = self.mask_by_grid.popitem()
 
             if valid_data_method is ValidDataMethod.bounds:
-                geom = box(*grid.bounds)
+                geom = box(*grid.boundingbox)
             elif valid_data_method is ValidDataMethod.filled:
                 mask = mask.astype("uint8")
                 binary_fill_holes(mask, output=mask)
@@ -495,7 +415,7 @@ class MeasurementBundler:
             for band_name, _ in measurements.items():
                 yield band_name
 
-    def iter_paths(self) -> Generator[tuple[GridSpec, str, Path], None, None]:
+    def iter_paths(self) -> Generator[tuple[GeoBox, str, Path], None, None]:
         """All current measurement paths on disk"""
         for grid, measurements in self._measurements_per_grid.items():
             for band_name, meas_path in measurements.items():
@@ -508,7 +428,7 @@ def _valid_shape(shape: BaseGeometry) -> BaseGeometry:
     return shape.buffer(0)
 
 
-def _grid_to_poly(grid: GridSpec, mask: numpy.ndarray) -> BaseGeometry:
+def _grid_to_poly(grid: GeoBox, mask: numpy.ndarray) -> BaseGeometry:
     shape = shapely.ops.unary_union(
         [
             _valid_shape(shapely.geometry.shape(shape))
@@ -530,529 +450,283 @@ def _grid_to_poly(grid: GridSpec, mask: numpy.ndarray) -> BaseGeometry:
     geom = shapely.affinity.affine_transform(
         geom,
         (
-            grid.transform.a,
-            grid.transform.b,
-            grid.transform.d,
-            grid.transform.e,
-            grid.transform.xoff,
-            grid.transform.yoff,
+            grid.affine.a,
+            grid.affine.b,
+            grid.affine.d,
+            grid.affine.e,
+            grid.affine.xoff,
+            grid.affine.yoff,
         ),
     )
     return geom
 
 
-@attr.s(auto_attribs=True)
-class WriteResult:
-    # path: Path
-
-    # The value to put in 'odc:file_format' metadata field.
-    file_format: FileFormat
-
-    # size_bytes: int
-
-
-class FileWrite:
+def create_thumbnail(
+    rgb: tuple[Path, Path, Path],
+    out: Path,
+    out_scale=10,
+    resampling=Resampling.average,
+    static_stretch: tuple[int, int] = None,
+    percentile_stretch: tuple[int, int] = (2, 98),
+    compress_quality: int = 85,
+    input_geobox: GeoBox = None,
+):
     """
-    Write COGs from arrays / files.
+    Generate a thumbnail jpg image using the given three paths as red,green, blue.
 
-    This code is derived from the old eugl packaging code and can probably be improved.
+    A linear stretch is performed on the colour. By default this is a dynamic 2% stretch
+    (the 2% and 98% percentile values of the input). The static_stretch parameter will
+    override this with a static range of values.
+
+    If the input image has a valid no data value, the no data will
+    be set to 0 in the output image.
+
+    Any non-contiguous data across the colour domain, will be set to
+    zero.
     """
+    # No aux.xml file with our jpeg.
+    with rasterio.Env(GDAL_PAM_ENABLED=False):
+        with tempfile.TemporaryDirectory(dir=out.parent, prefix=".thumbgen-") as tmpdir:
+            tmp_quicklook_path = Path(tmpdir) / "quicklook.tif"
 
-    PREDICTOR_DEFAULTS: ClassVar[dict[str, int]] = {
-        "int8": 2,
-        "uint8": 2,
-        "int16": 2,
-        "uint16": 2,
-        "int32": 2,
-        "uint32": 2,
-        "int64": 2,
-        "uint64": 2,
-        "float32": 3,
-        "float64": 3,
-    }
-
-    def __init__(
-        self,
-        gdal_options: dict = None,
-        overview_blocksize: int | None = None,
-    ) -> None:
-        super().__init__()
-        self.options = gdal_options or {}
-        self.overview_blocksize = overview_blocksize
-
-    @classmethod
-    def from_existing(
-        cls,
-        shape: tuple[int, int],
-        overviews: bool = True,
-        blocksize_yx: tuple[int, int] | None = None,
-        overview_blocksize: int | None = None,
-        compress="deflate",
-        zlevel=4,
-    ) -> "FileWrite":
-        """Returns write_img options according to the source imagery provided
-        :param overviews:
-            (boolean) sets overview flags in gdal config options
-        :param blockxsize:
-            (int) override the derived base blockxsize in cogtif conversion
-        :param blockysize:
-            (int) override the derived base blockysize in cogtif conversion
-
-        """
-        options = {"compress": compress, "zlevel": zlevel}
-
-        y_size, x_size = blocksize_yx or (512, 512)
-        # Do not set block sizes for small imagery
-        if shape[0] < y_size and shape[1] < x_size:
-            pass
-        else:
-            options["blockxsize"] = x_size
-            options["blockysize"] = y_size
-            options["tiled"] = "yes"
-
-        if overviews:
-            options["copy_src_overviews"] = "yes"
-
-        return FileWrite(options, overview_blocksize=overview_blocksize)
-
-    def write_from_ndarray(
-        self,
-        array: numpy.ndarray,
-        out_filename: Path,
-        geobox: GridSpec = None,
-        nodata: int = None,
-        overview_resampling=Resampling.nearest,
-        overviews: tuple[int, ...] | None = DEFAULT_OVERVIEWS,
-    ) -> WriteResult:
-        """
-        Writes a 2D/3D image to disk using rasterio.
-
-        :param array:
-            A 2D/3D NumPy array.
-
-        :param out_filename:
-            A string containing the output file name.
-
-        :param geobox:
-            An instance of a GriddedGeoBox object.
-
-        :param nodata:
-            A value representing the no data value for the array.
-
-        :param overview_resampling:
-            If levels is set, build overviews using a resampling method
-            from `rasterio.enums.Resampling`
-            Default is `Resampling.nearest`.
-
-        :notes:
-            If array is an instance of a `h5py.Dataset`, then the output
-            file will include blocksizes based on the `h5py.Dataset's`
-            chunks. To override the blocksizes, specify them using the
-            `options` keyword. Eg {'blockxsize': 512, 'blockysize': 512}.
-        """
-        if out_filename.exists():
-            # Sanity check. Our measurements should have different names...
-            raise RuntimeError(
-                f"measurement output file already exists? {out_filename}"
+            # We write an intensity-scaled, reprojected version of the dataset at full res.
+            # Then write a scaled JPEG verison. (TODO: can we do it in one step?)
+            ql_grid = _write_quicklook(
+                rgb,
+                tmp_quicklook_path,
+                resampling,
+                static_range=static_stretch,
+                percentile_range=percentile_stretch,
+                input_geobox=input_geobox,
             )
+            out_crs = ql_grid.crs
 
-        # TODO: Old packager never passed in tags. Perhaps we want some?
-        tags = {}
-
-        dtype = array.dtype.name
-
-        # Check for excluded datatypes
-        excluded_dtypes = ["int64", "int8", "uint64"]
-        if dtype in excluded_dtypes:
-            raise TypeError(f"Datatype not supported: {dtype}")
-
-        # convert any bools to uin8
-        if dtype == "bool":
-            array = numpy.uint8(array)
-            dtype = "uint8"
-
-        ndims = array.ndim
-        shape = array.shape
-
-        # Get the (z, y, x) dimensions (assuming BSQ interleave)
-        if ndims == 2:
-            samples = shape[1]
-            lines = shape[0]
-            bands = 1
-        elif ndims == 3:
-            samples = shape[2]
-            lines = shape[1]
-            bands = shape[0]
-        else:
-            raise IndexError(f"Input array is not of 2 or 3 dimensions. Got {ndims}")
-
-        transform = None
-        projection = None
-        if geobox is not None:
-            transform = geobox.transform
-            projection = geobox.crs
-
-        rio_args = {
-            "count": bands,
-            "width": samples,
-            "height": lines,
-            "crs": projection,
-            "transform": transform,
-            "dtype": dtype,
-            "driver": "GTiff",
-            "predictor": self.PREDICTOR_DEFAULTS[dtype],
-        }
-        if nodata is not None:
-            rio_args["nodata"] = nodata
-
-        if h5py is not None and isinstance(array, h5py.Dataset):
-            # TODO: if array is 3D get x & y chunks
-            if array.chunks[1] == array.shape[1]:
-                # GDAL doesn't like tiled or blocksize options to be set
-                # the same length as the columns (probably true for rows as well)
-                array = array[:]
-            else:
-                y_tile, x_tile = array.chunks
-                tiles = generate_tiles(samples, lines, x_tile, y_tile)
-
-                if "tiled" in self.options:
-                    rio_args["blockxsize"] = self.options.get("blockxsize", x_tile)
-                    rio_args["blockysize"] = self.options.get("blockysize", y_tile)
-
-        # the user can override any derived blocksizes by supplying `options`
-        # handle case where no options are provided
-        for key in self.options:
-            rio_args[key] = self.options[key]
-
-        # Write to temp directory first so we can add levels afterwards with gdal.
-        with tempfile.TemporaryDirectory(
-            dir=out_filename.parent, prefix=".band_write"
-        ) as tmpdir:
-            unstructured_image = Path(tmpdir) / out_filename.name
-            """
-            This is a wrapper around rasterio writing tiles to
-            enable writing to a temporary location before rearranging
-            the overviews within the file by gdal when required
-            """
-            with rasterio.open(unstructured_image, "w", **rio_args) as outds:
-                if bands == 1:
-                    if h5py is not None and isinstance(array, h5py.Dataset):
-                        for tile in tiles:
-                            idx = (
-                                slice(tile[0][0], tile[0][1]),
-                                slice(tile[1][0], tile[1][1]),
-                            )
-                            outds.write(array[idx], 1, window=tile)
-                    else:
-                        outds.write(array, 1)
-                else:
-                    if h5py is not None and isinstance(array, h5py.Dataset):
-                        for tile in tiles:
-                            idx = (
-                                slice(tile[0][0], tile[0][1]),
-                                slice(tile[1][0], tile[1][1]),
-                            )
-                            subs = array[:, idx[0], idx[1]]
-                            for i in range(bands):
-                                outds.write(subs[i], i + 1, window=tile)
-                    else:
-                        for i in range(bands):
-                            outds.write(array[i], i + 1)
-                if tags is not None:
-                    outds.update_tags(**tags)
-
-                # overviews/pyramids to disk
-                if overviews:
-                    outds.build_overviews(overviews, overview_resampling)
-
-            if overviews:
-                # Move the overviews to the start of the file, as required to be COG-compliant.
-                with rasterio.Env(
-                    GDAL_TIFF_OVR_BLOCKSIZE=self.overview_blocksize or 512
-                ):
-                    rio_copy(
-                        unstructured_image,
-                        out_filename,
-                        **{"copy_src_overviews": True, **rio_args},
-                    )
-            else:
-                unstructured_image.rename(out_filename)
-
-        return WriteResult(file_format=FileFormat.GeoTIFF)
-
-    def create_thumbnail(
-        self,
-        rgb: tuple[Path, Path, Path],
-        out: Path,
-        out_scale=10,
-        resampling=Resampling.average,
-        static_stretch: tuple[int, int] = None,
-        percentile_stretch: tuple[int, int] = (2, 98),
-        compress_quality: int = 85,
-        input_geobox: GridSpec = None,
-    ):
-        """
-        Generate a thumbnail jpg image using the given three paths as red,green, blue.
-
-        A linear stretch is performed on the colour. By default this is a dynamic 2% stretch
-        (the 2% and 98% percentile values of the input). The static_stretch parameter will
-        override this with a static range of values.
-
-        If the input image has a valid no data value, the no data will
-        be set to 0 in the output image.
-
-        Any non-contiguous data across the colour domain, will be set to
-        zero.
-        """
-        # No aux.xml file with our jpeg.
-        with rasterio.Env(GDAL_PAM_ENABLED=False):
-            with tempfile.TemporaryDirectory(
-                dir=out.parent, prefix=".thumbgen-"
-            ) as tmpdir:
-                tmp_quicklook_path = Path(tmpdir) / "quicklook.tif"
-
-                # We write an intensity-scaled, reprojected version of the dataset at full res.
-                # Then write a scaled JPEG verison. (TODO: can we do it in one step?)
-                ql_grid = _write_quicklook(
-                    rgb,
-                    tmp_quicklook_path,
-                    resampling,
-                    static_range=static_stretch,
-                    percentile_range=percentile_stretch,
-                    input_geobox=input_geobox,
-                )
-                out_crs = ql_grid.crs
-
-                # Scale and write as JPEG to the output.
-                (
-                    thumb_transform,
-                    thumb_width,
-                    thumb_height,
-                ) = calculate_default_transform(
-                    out_crs,
-                    out_crs,
-                    ql_grid.shape[1],
-                    ql_grid.shape[0],
-                    *ql_grid.bounds,
-                    dst_width=ql_grid.shape[1] // out_scale,
-                    dst_height=ql_grid.shape[0] // out_scale,
-                )
-                thumb_args = dict(
-                    driver="JPEG",
-                    quality=compress_quality,
-                    height=thumb_height,
-                    width=thumb_width,
-                    count=3,
-                    dtype="uint8",
-                    nodata=0,
-                    transform=thumb_transform,
-                    crs=out_crs,
-                )
-                with rasterio.open(tmp_quicklook_path, "r") as ql_ds:
-                    ql_ds: DatasetReader
-                    with rasterio.open(out, "w", **thumb_args) as thumb_ds:
-                        thumb_ds: DatasetWriter
-                        for index in thumb_ds.indexes:
-                            thumb_ds.write(
-                                ql_ds.read(
-                                    index,
-                                    out_shape=(thumb_height, thumb_width),
-                                    resampling=resampling,
-                                ),
+            # Scale and write as JPEG to the output.
+            (
+                thumb_transform,
+                thumb_width,
+                thumb_height,
+            ) = calculate_default_transform(
+                out_crs,
+                out_crs,
+                ql_grid.shape[1],
+                ql_grid.shape[0],
+                *ql_grid.boundingbox,
+                dst_width=ql_grid.shape[1] // out_scale,
+                dst_height=ql_grid.shape[0] // out_scale,
+            )
+            thumb_args = dict(
+                driver="JPEG",
+                quality=compress_quality,
+                height=thumb_height,
+                width=thumb_width,
+                count=3,
+                dtype="uint8",
+                nodata=0,
+                transform=thumb_transform,
+                crs=out_crs,
+            )
+            with rasterio.open(tmp_quicklook_path, "r") as ql_ds:
+                ql_ds: DatasetReader
+                with rasterio.open(out, "w", **thumb_args) as thumb_ds:
+                    thumb_ds: DatasetWriter
+                    for index in thumb_ds.indexes:
+                        thumb_ds.write(
+                            ql_ds.read(
                                 index,
-                            )
+                                out_shape=(thumb_height, thumb_width),
+                                resampling=resampling,
+                            ),
+                            index,
+                        )
 
-    def create_thumbnail_from_numpy(
-        self,
-        rgb: tuple[numpy.array, numpy.array, numpy.array],
-        out_scale=10,
-        resampling=Resampling.average,
-        static_stretch: tuple[int, int] = None,
-        percentile_stretch: tuple[int, int] = (2, 98),
-        compress_quality: int = 85,
-        input_geobox: GridSpec = None,
-        nodata: int = -999,
-    ):
-        """
-        Generate a thumbnail as numpy arrays.
 
-        Unlike the default `create_thumbnail` function, this is done entirely in-memory. It will likely require more
-        memory but does not touch the filesystem.
+def create_thumbnail_from_numpy(
+    rgb: tuple[numpy.array, numpy.array, numpy.array],
+    out_scale=10,
+    resampling=Resampling.average,
+    static_stretch: tuple[int, int] = None,
+    percentile_stretch: tuple[int, int] = (2, 98),
+    compress_quality: int = 85,
+    input_geobox: GeoBox = None,
+    nodata: int = -999,
+):
+    """
+    Generate a thumbnail as numpy arrays.
 
-        A linear stretch is performed on the colour. By default this is a dynamic 2% stretch
-        (the 2% and 98% percentile values of the input). The static_stretch parameter will
-        override this with a static range of values.
+    Unlike the default `create_thumbnail` function, this is done entirely in-memory. It will likely require more
+    memory but does not touch the filesystem.
 
-        Any non-contiguous data across the colour domain, will be set to zero.
-        """
-        ql_grid, numpy_array_list, ql_write_args = _write_to_numpy_array(
-            rgb,
-            resampling,
-            static_range=static_stretch,
-            percentile_range=percentile_stretch,
-            input_geobox=input_geobox,
-            nodata=nodata,
-        )
-        out_crs = ql_grid.crs
+    A linear stretch is performed on the colour. By default this is a dynamic 2% stretch
+    (the 2% and 98% percentile values of the input). The static_stretch parameter will
+    override this with a static range of values.
 
-        # Scale and write as JPEG to the output.
-        (
-            thumb_transform,
-            thumb_width,
-            thumb_height,
-        ) = calculate_default_transform(
-            out_crs,
-            out_crs,
-            ql_grid.shape[1],
-            ql_grid.shape[0],
-            *ql_grid.bounds,
-            dst_width=ql_grid.shape[1] // out_scale,
-            dst_height=ql_grid.shape[0] // out_scale,
-        )
-        thumb_args = dict(
-            driver="JPEG",
-            quality=compress_quality,
-            height=thumb_height,
-            width=thumb_width,
-            count=3,
-            dtype="uint8",
-            nodata=0,
-            transform=thumb_transform,
-            crs=out_crs,
-        )
+    Any non-contiguous data across the colour domain, will be set to zero.
+    """
+    ql_grid, numpy_array_list, ql_write_args = _write_to_numpy_array(
+        rgb,
+        resampling,
+        static_range=static_stretch,
+        percentile_range=percentile_stretch,
+        input_geobox=input_geobox,
+        nodata=nodata,
+    )
+    out_crs = ql_grid.crs
 
-        with MemoryFile() as mem_tif_file:
-            with mem_tif_file.open(**ql_write_args) as dataset:
-                for i, data in enumerate(numpy_array_list):
-                    dataset.write(data, i + 1)
+    # Scale and write as JPEG to the output.
+    (
+        thumb_transform,
+        thumb_width,
+        thumb_height,
+    ) = calculate_default_transform(
+        out_crs,
+        out_crs,
+        ql_grid.shape[1],
+        ql_grid.shape[0],
+        *ql_grid.boundingbox,
+        dst_width=ql_grid.shape[1] // out_scale,
+        dst_height=ql_grid.shape[0] // out_scale,
+    )
+    thumb_args = dict(
+        driver="JPEG",
+        quality=compress_quality,
+        height=thumb_height,
+        width=thumb_width,
+        count=3,
+        dtype="uint8",
+        nodata=0,
+        transform=thumb_transform,
+        crs=out_crs,
+    )
 
-                with MemoryFile() as mem_jpg_file:
-                    with mem_jpg_file.open(**thumb_args) as thumbnail:
-                        for index in thumbnail.indexes:
-                            thumbnail.write(  # write the data from temp_tif to temp_jpg
-                                dataset.read(
-                                    index,
-                                    out_shape=(thumb_height, thumb_width),
-                                    resampling=Resampling.average,
-                                ),
+    with MemoryFile() as mem_tif_file:
+        with mem_tif_file.open(**ql_write_args) as dataset:
+            for i, data in enumerate(numpy_array_list):
+                dataset.write(data, i + 1)
+
+            with MemoryFile() as mem_jpg_file:
+                with mem_jpg_file.open(**thumb_args) as thumbnail:
+                    for index in thumbnail.indexes:
+                        thumbnail.write(  # write the data from temp_tif to temp_jpg
+                            dataset.read(
                                 index,
-                            )
+                                out_shape=(thumb_height, thumb_width),
+                                resampling=Resampling.average,
+                            ),
+                            index,
+                        )
 
-                    return_bytes = mem_jpg_file.read()
+                return_bytes = mem_jpg_file.read()
 
-        return return_bytes
+    return return_bytes
 
-    def create_thumbnail_singleband(
-        self,
-        in_file: Path,
-        out_file: Path,
-        bit: int = None,
-        lookup_table: dict[int, tuple[int, int, int]] = None,
-    ):
-        """
-        Write out a JPG thumbnail from a singleband image.
-        This takes in a path to a valid raster dataset and writes
-        out a file with only the values of the bit (integer) as white
-        """
-        if bit is not None and lookup_table is not None:
-            raise ValueError(
-                "Please set either bit or lookup_table, and not both of them"
-            )
-        if bit is None and lookup_table is None:
-            raise ValueError(
-                "Please set either bit or lookup_table, you haven't set either of them"
-            )
 
-        with rasterio.open(in_file) as dataset:
-            data = dataset.read()
-            out_data, stretch = self._filter_singleband_data(data, bit, lookup_table)
+def create_thumbnail_singleband(
+    in_file: Path,
+    out_file: Path,
+    bit: int = None,
+    lookup_table: dict[int, tuple[int, int, int]] = None,
+):
+    """
+    Write out a JPG thumbnail from a singleband image.
+    This takes in a path to a valid raster dataset and writes
+    out a file with only the values of the bit (integer) as white
+    """
+    if bit is not None and lookup_table is not None:
+        raise ValueError("Please set either bit or lookup_table, and not both of them")
+    if bit is None and lookup_table is None:
+        raise ValueError(
+            "Please set either bit or lookup_table, you haven't set either of them"
+        )
 
-        meta = dataset.meta
-        meta["driver"] = "GTiff"
+    with rasterio.open(in_file) as dataset:
+        data = dataset.read()
+        out_data, stretch = _filter_singleband_data(data, bit, lookup_table)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            if bit:
-                # Only use one file, three times
-                temp_file = Path(temp_dir) / "temp.tif"
+    meta = dataset.meta
+    meta["driver"] = "GTiff"
 
-                with rasterio.open(temp_file, "w", **meta) as tmpdataset:
-                    tmpdataset.write(out_data)
-                self.create_thumbnail(
-                    (temp_file, temp_file, temp_file),
-                    out_file,
-                    static_stretch=stretch,
-                )
-            else:
-                # Use three different files
-                temp_files = tuple(Path(temp_dir) / f"temp_{i}.tif" for i in range(3))
-
-                for i in range(3):
-                    with rasterio.open(temp_files[i], "w", **meta) as tmpdataset:
-                        tmpdataset.write(out_data[i])
-                self.create_thumbnail(temp_files, out_file, static_stretch=stretch)
-
-    def create_thumbnail_singleband_from_numpy(
-        self,
-        input_data: numpy.array,
-        bit: int = None,
-        lookup_table: dict[int, tuple[int, int, int]] = None,
-        input_geobox: GridSpec = None,
-        nodata: int = -999,
-    ) -> bytes:
-        """
-        Output a thumbnail ready bytes from the input numpy array.
-        This takes a valid raster data (numpy arrary) and return
-        out bytes with only the values of the bit (integer) as white.
-        """
-        if bit is not None and lookup_table is not None:
-            raise ValueError(
-                "Please set either bit or lookup_table, and not both of them"
-            )
-        if bit is None and lookup_table is None:
-            raise ValueError(
-                "Please set either bit or lookup_table, you haven't set either of them"
-            )
-
-        out_data, stretch = self._filter_singleband_data(input_data, bit, lookup_table)
-
+    with tempfile.TemporaryDirectory() as temp_dir:
         if bit:
-            rgb = [out_data, out_data, out_data]
-        else:
-            rgb = out_data
+            # Only use one file, three times
+            temp_file = Path(temp_dir) / "temp.tif"
 
-        return self.create_thumbnail_from_numpy(
-            rgb=rgb,
-            static_stretch=stretch,
-            input_geobox=input_geobox,
-            nodata=nodata,
+            with rasterio.open(temp_file, "w", **meta) as tmpdataset:
+                tmpdataset.write(out_data)
+            create_thumbnail(
+                (temp_file, temp_file, temp_file),
+                out_file,
+                static_stretch=stretch,
+            )
+        else:
+            # Use three different files
+            temp_files = tuple(Path(temp_dir) / f"temp_{i}.tif" for i in range(3))
+
+            for i in range(3):
+                with rasterio.open(temp_files[i], "w", **meta) as tmpdataset:
+                    tmpdataset.write(out_data[i])
+            create_thumbnail(temp_files, out_file, static_stretch=stretch)
+
+
+def create_thumbnail_singleband_from_numpy(
+    input_data: numpy.array,
+    bit: int = None,
+    lookup_table: dict[int, tuple[int, int, int]] = None,
+    input_geobox: GeoBox = None,
+    nodata: int = -999,
+) -> bytes:
+    """
+    Output a thumbnail ready bytes from the input numpy array.
+    This takes a valid raster data (numpy arrary) and return
+    out bytes with only the values of the bit (integer) as white.
+    """
+    if bit is not None and lookup_table is not None:
+        raise ValueError("Please set either bit or lookup_table, and not both of them")
+    if bit is None and lookup_table is None:
+        raise ValueError(
+            "Please set either bit or lookup_table, you haven't set either of them"
         )
 
-    def _filter_singleband_data(
-        self,
-        data: numpy.array,
-        bit: int = None,
-        lookup_table: dict[int, tuple[int, int, int]] = None,
-    ):
-        """
-        Apply bit or lookup_table to filter the numpy array
-        and generate the thumbnail content.
-        """
-        if bit is not None:
-            out_data = numpy.copy(data)
-            out_data[data != bit] = 0
-            stretch = (0, bit)
-        if lookup_table is not None:
-            out_data = [
-                numpy.full_like(data, 0),
-                numpy.full_like(data, 0),
-                numpy.full_like(data, 0),
-            ]
-            stretch = (0, 255)
+    out_data, stretch = _filter_singleband_data(input_data, bit, lookup_table)
 
-            for value, rgb in lookup_table.items():
-                for index in range(3):
-                    out_data[index][data == value] = rgb[index]
-        return out_data, stretch
+    if bit:
+        rgb = [out_data, out_data, out_data]
+    else:
+        rgb = out_data
+
+    return create_thumbnail_from_numpy(
+        rgb=rgb,
+        static_stretch=stretch,
+        input_geobox=input_geobox,
+        nodata=nodata,
+    )
+
+
+def _filter_singleband_data(
+    data: numpy.array,
+    bit: int = None,
+    lookup_table: dict[int, tuple[int, int, int]] = None,
+):
+    """
+    Apply bit or lookup_table to filter the numpy array
+    and generate the thumbnail content.
+    """
+    if bit is not None:
+        out_data = numpy.copy(data)
+        out_data[data != bit] = 0
+        stretch = (0, bit)
+    if lookup_table is not None:
+        out_data = [
+            numpy.full_like(data, 0),
+            numpy.full_like(data, 0),
+            numpy.full_like(data, 0),
+        ]
+        stretch = (0, 255)
+
+        for value, rgb in lookup_table.items():
+            for index in range(3):
+                out_data[index][data == value] = rgb[index]
+    return out_data, stretch
 
 
 def _write_to_numpy_array(
@@ -1060,9 +734,9 @@ def _write_to_numpy_array(
     resampling: Resampling,
     static_range: tuple[int, int],
     percentile_range: tuple[int, int] = (2, 98),
-    input_geobox: GridSpec = None,
+    input_geobox: GeoBox = None,
     nodata: int = -999,
-) -> GridSpec:
+) -> GeoBox:
     """
     Write an intensity-scaled wgs84 image using the given files as bands.
     """
@@ -1079,9 +753,9 @@ def _write_to_numpy_array(
         out_crs,
         input_geobox.shape[1],
         input_geobox.shape[0],
-        *input_geobox.bounds,
+        *input_geobox.boundingbox,
     )
-    reproj_grid = GridSpec(
+    reproj_grid = GeoBox(
         (reprojected_height, reprojected_width), reprojected_transform, crs=out_crs
     )
     ql_write_args = dict(
@@ -1090,7 +764,7 @@ def _write_to_numpy_array(
         count=len(rgb),
         width=reproj_grid.shape[1],
         height=reproj_grid.shape[0],
-        transform=reproj_grid.transform,
+        transform=reproj_grid.affine,
         crs=reproj_grid.crs,
         nodata=0,
         tiled="yes",
@@ -1124,11 +798,11 @@ def _write_to_numpy_array(
             ),
             reprojected_data,
             src_crs=input_geobox.crs,
-            src_transform=input_geobox.transform,
+            src_transform=input_geobox.affine,
             src_nodata=0,
             dst_crs=reproj_grid.crs,
             dst_nodata=0,
-            dst_transform=reproj_grid.transform,
+            dst_transform=reproj_grid.affine,
             resampling=resampling,
             num_threads=2,
         )
@@ -1144,16 +818,16 @@ def _write_quicklook(
     resampling: Resampling,
     static_range: tuple[int, int],
     percentile_range: tuple[int, int] = (2, 98),
-    input_geobox: GridSpec = None,
-) -> GridSpec:
+    input_geobox: GeoBox = None,
+) -> GeoBox:
     """
     Write an intensity-scaled wgs84 image using the given files as bands.
     """
     if input_geobox is None:
         with rasterio.open(rgb[0]) as ds:
-            input_geobox = GridSpec.from_rio(ds)
+            input_geobox = GeoBox.from_rio(ds)
 
-    out_crs = CRS.from_epsg(4326)
+    out_crs = CRS(4326)
     (
         reprojected_transform,
         reprojected_width,
@@ -1163,9 +837,9 @@ def _write_quicklook(
         out_crs,
         input_geobox.shape[1],
         input_geobox.shape[0],
-        *input_geobox.bounds,
+        *input_geobox.boundingbox,
     )
-    reproj_grid = GridSpec(
+    reproj_grid = GeoBox(
         (reprojected_height, reprojected_width), reprojected_transform, crs=out_crs
     )
     ql_write_args = dict(
@@ -1174,7 +848,7 @@ def _write_quicklook(
         count=len(rgb),
         width=reproj_grid.shape[1],
         height=reproj_grid.shape[0],
-        transform=reproj_grid.transform,
+        transform=reproj_grid.affine,
         crs=reproj_grid.crs,
         nodata=0,
         tiled="yes",
@@ -1207,11 +881,11 @@ def _write_quicklook(
                 ),
                 reprojected_data,
                 src_crs=input_geobox.crs,
-                src_transform=input_geobox.transform,
+                src_transform=input_geobox.affine,
                 src_nodata=0,
                 dst_crs=reproj_grid.crs,
                 dst_nodata=0,
-                dst_transform=reproj_grid.transform,
+                dst_transform=reproj_grid.affine,
                 resampling=resampling,
                 num_threads=2,
             )

--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -743,7 +743,7 @@ def _write_to_numpy_array(
     if input_geobox is None:
         raise NotImplementedError("generating geobox from numpy is't yet supported")
 
-    out_crs = CRS.from_epsg(4326)
+    out_crs = CRS(4326)
     (
         reprojected_transform,
         reprojected_width,

--- a/eodatasets3/prepare/esri_land_cover_prepare.py
+++ b/eodatasets3/prepare/esri_land_cover_prepare.py
@@ -2,9 +2,10 @@ import uuid
 from pathlib import Path
 
 import rasterio
+from odc.geo.geobox import GeoBox
 from shapely.geometry import box
 
-from eodatasets3 import DatasetPrepare, GridSpec
+from eodatasets3 import DatasetPrepare
 
 _ESRI_ID_NAMESPACE = uuid.UUID("88a620e0-6b62-462b-9b23-4027e05898f3")
 
@@ -20,13 +21,13 @@ def as_eo3(uri: str):
     path = Path(uri)
 
     with rasterio.open(uri, GEOREF_SOURCES="INTERNAL") as opened_asset:
-        grid_spec = GridSpec.from_rio(opened_asset)
+        geobox = GeoBox.from_rio(opened_asset)
         bbox = opened_asset.bounds
         nodata = opened_asset.nodata
 
     region, date_range = path.stem.split("_")
     start_date, end_date = date_range.split("-")
-    if grid_spec.crs is None:
+    if geobox.crs is None:
         print(f"Empty CRS: {uri}")
         return None
 
@@ -50,7 +51,7 @@ def as_eo3(uri: str):
         "classification",
         uri,
         relative_to_dataset_location=True,
-        grid=grid_spec,
+        geobox=geobox,
         expand_valid_data=False,
         nodata=nodata,
     )

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -286,9 +286,7 @@ def mask_h5_vector(
             shapes,
             out_shape=data_array.shape,
             fill=0,
-            transform=Affine.from_gdal(
-                *[val.item() for val in dataset.attrs["geotransform"]]
-            ),
+            transform=Affine.from_gdal(*dataset.attrs["geotransform"]),
         )
         return numpy.where(mask_array == 0, data_array, dataset.attrs["no_data_value"])
 
@@ -341,7 +339,7 @@ def write_measurement_h5(
         array=data,
         geobox=GeoBox(
             shape=g.shape,
-            affine=Affine.from_gdal(*[val.item() for val in g.attrs["geotransform"]]),
+            affine=Affine.from_gdal(*g.attrs["geotransform"]),
             crs=CRS(g.attrs["crs_wkt"]).to_wkt(),
         ),
         nodata=g.attrs.get("no_data_value"),

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -342,7 +342,7 @@ def write_measurement_h5(
         geobox=GeoBox(
             shape=g.shape,
             affine=Affine.from_gdal(*[val.item() for val in g.attrs["geotransform"]]),
-            crs=CRS(g.attrs["crs_wkt"]),
+            crs=CRS(g.attrs["crs_wkt"]).to_wkt(),
         ),
         nodata=g.attrs.get("no_data_value"),
         overviews=overviews,
@@ -473,7 +473,8 @@ def _create_contiguity(
                 ds: DatasetReader
                 out_shape = ds.shape
                 contiguity = numpy.ones(out_shape, dtype="uint8")
-                geobox = GeoBox.from_rio(ds)
+                # geobox = GeoBox.from_rio(ds)
+                geobox = GeoBox(ds.shape, ds.transform, CRS(ds.crs).to_wkt())
                 break
 
         if contiguity is None:

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -340,7 +340,7 @@ def write_measurement_h5(
         geobox=GeoBox(
             shape=g.shape,
             affine=Affine.from_gdal(*g.attrs["geotransform"]),
-            crs=CRS(g.attrs["crs_wkt"]).to_wkt(),
+            crs=CRS(g.attrs["crs_wkt"]),
         ),
         nodata=g.attrs.get("no_data_value"),
         overviews=overviews,
@@ -471,8 +471,7 @@ def _create_contiguity(
                 ds: DatasetReader
                 out_shape = ds.shape
                 contiguity = numpy.ones(out_shape, dtype="uint8")
-                # geobox = GeoBox.from_rio(ds)
-                geobox = GeoBox(ds.shape, ds.transform, CRS(ds.crs).to_wkt())
+                geobox = GeoBox.from_rio(ds)
                 break
 
         if contiguity is None:

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -339,7 +339,7 @@ def write_measurement_h5(
         geobox=GeoBox(
             shape=g.shape,
             affine=Affine.from_gdal(*g.attrs["geotransform"]),
-            crs=CRS.from_wkt(g.attrs["crs_wkt"]),
+            crs=CRS(g.attrs["crs_wkt"]),
         ),
         nodata=g.attrs.get("no_data_value"),
         overviews=overviews,

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -286,7 +286,9 @@ def mask_h5_vector(
             shapes,
             out_shape=data_array.shape,
             fill=0,
-            transform=Affine.from_gdal(*dataset.attrs["geotransform"]),
+            transform=Affine.from_gdal(
+                *[val.item() for val in dataset.attrs["geotransform"]]
+            ),
         )
         return numpy.where(mask_array == 0, data_array, dataset.attrs["no_data_value"])
 
@@ -339,7 +341,7 @@ def write_measurement_h5(
         array=data,
         geobox=GeoBox(
             shape=g.shape,
-            affine=Affine.from_gdal(*g.attrs["geotransform"]),
+            affine=Affine.from_gdal(*[val.item() for val in g.attrs["geotransform"]]),
             crs=CRS(g.attrs["crs_wkt"]),
         ),
         nodata=g.attrs.get("no_data_value"),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ README = (HERE / "README.md").read_text(encoding="utf-8")
 
 
 tests_require = [
-    "deepdiff",
+    "deepdiff>=8.0.0",
     "gdal",
     "mock",
     "pep8-naming",
@@ -78,7 +78,7 @@ setup(
         "fiona",
         "h5py",
         "jsonschema>=4.18",  # We want a Draft6Validator
-        "numpy>=1.15.4",
+        "numpy>=1.15.4,<2.0",
         "pyproj",
         "rasterio",
         "ruamel.yaml",

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
         "datacube>=1.9.0-rc4",
         "python-rapidjson",
         "pystac>=1.8.4",
+        "odc-geo",
     ],
     tests_require=tests_require,
     extras_require=EXTRAS_REQUIRE,

--- a/tests/common.py
+++ b/tests/common.py
@@ -200,12 +200,12 @@ def format_doc_diffs(left: dict, right: dict) -> Iterable[str]:
             )
     if "dictionary_item_added" in doc_diffs:
         out.append("Added fields:")
-        for offset in doc_diffs.tree["dictionary_item_added"].items:
+        for offset in doc_diffs.tree["dictionary_item_added"]:
             offset: DiffLevel
             out.append(f"    {clean_offset(offset.path())} = {offset.t2!r}")
     if "dictionary_item_removed" in doc_diffs:
         out.append("Removed fields:")
-        for offset in doc_diffs.tree["dictionary_item_removed"].items:
+        for offset in doc_diffs.tree["dictionary_item_removed"]:
             offset: DiffLevel
             out.append(f"    {clean_offset(offset.path())} = {offset.t1!r}")
     # Anything we missed from the (sometimes changing) diff api?

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -16,8 +16,9 @@ import pytest
 from ruamel import yaml
 
 from eodatasets3 import DatasetAssembler, DatasetPrepare, namer, serialise
-from eodatasets3.images import GridSpec
+from eodatasets3.images import gbox_from_dataset_doc, gbox_from_path
 from eodatasets3.model import DatasetDoc
+from eodatasets3.utils import default_utc
 from tests import assert_file_structure
 from tests.common import assert_expected_eo3_path, assert_same
 
@@ -26,6 +27,7 @@ def test_dea_style_package(
     l1_ls8_dataset: DatasetDoc, l1_ls8_dataset_path: Path, tmp_path: Path
 ):
     out = tmp_path
+    print(l1_ls8_dataset.properties["datetime"])
 
     [blue_geotiff_path] = l1_ls8_dataset_path.rglob("L*_B2.TIF")
 
@@ -48,7 +50,7 @@ def test_dea_style_package(
         p.write_measurement_numpy(
             "ones",
             numpy.ones((60, 60), numpy.int16),
-            GridSpec.from_dataset_doc(l1_ls8_dataset),
+            gbox_from_dataset_doc(l1_ls8_dataset),
             nodata=-999,
         )
 
@@ -143,11 +145,11 @@ def test_dea_style_package(
                 "ones": {"path": "ga_ls8c_ones_3-0-0_090084_2016-01-21_final_ones.tif"},
             },
             "properties": {
-                "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435),
+                "datetime": default_utc(datetime(2016, 1, 21, 23, 50, 23, 54435)),
                 "dea:dataset_maturity": "final",
                 "odc:dataset_version": "3.0.0",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": "2016-03-04T14:23:30",
+                "odc:processing_datetime": "2016-03-04T14:23:30+00:00",
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "ones",
                 # The remaining fields were inherited from the source dataset
@@ -256,7 +258,7 @@ def test_in_memory_dataset(tmp_path: Path, l1_ls8_folder: Path):
         pretend_path,
         # We give it grid information, so it doesn't have to read it itself.
         # (reading will fail if it tries, because the path is fake!)
-        grid=GridSpec.from_path(blue_geotiff_path),
+        geobox=gbox_from_path(blue_geotiff_path),
         pixels=numpy.ones((60, 60), numpy.int16),
         nodata=-1,
     )

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -682,7 +682,7 @@ def test_maturity_calculation():
 @contextmanager
 def expect_no_warnings():
     """Throw an assertion error if any warnings are produced."""
-    with pytest.warns(None) as warning_record:
+    with pytest.warns(Warning) as warning_record:
         yield
 
     # We could tighten this to specific warnings if it proves too noisy, but it's

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -453,7 +453,7 @@ def test_whole_landsat_wagl_package(
         assert d.width == 156
 
         # The reduced resolution makes it hard to test the chosen block size...
-        assert d.block_shapes == [(26, 156)]
+        assert d.block_shapes == [(160, 160)]
 
     # Check the overviews use default 512 block size.
     #     (Rasterio doesn't seem to have an api for this?)

--- a/tests/integration/test_thumbnail.py
+++ b/tests/integration/test_thumbnail.py
@@ -2,27 +2,27 @@ import tempfile
 from pathlib import Path
 
 import rasterio
+from odc.geo.geobox import GeoBox
 
-from eodatasets3.images import FileWrite, GridSpec
+from eodatasets3.images import (
+    create_thumbnail_singleband,
+    create_thumbnail_singleband_from_numpy,
+)
 
 from . import assert_image
 
 
 def test_thumbnail_bitflag(input_uint8_tif: Path):
-    writer = FileWrite()
-
     outfile = Path(tempfile.gettempdir()) / "test-bitflag.jpg"
 
     water = 128
 
-    writer.create_thumbnail_singleband(input_uint8_tif, Path(outfile), bit=water)
+    create_thumbnail_singleband(input_uint8_tif, Path(outfile), bit=water)
 
     assert_image(outfile, bands=3)
 
 
 def test_thumbnail_lookuptable(input_uint8_tif_2: Path):
-    writer = FileWrite()
-
     outfile = Path(tempfile.gettempdir()) / "test-lookuptable.jpg"
 
     wofs_lookup = {
@@ -37,7 +37,7 @@ def test_thumbnail_lookuptable(input_uint8_tif_2: Path):
         192: [186, 211, 242],  # cloudy water
     }
 
-    writer.create_thumbnail_singleband(
+    create_thumbnail_singleband(
         input_uint8_tif_2, Path(outfile), lookup_table=wofs_lookup
     )
 
@@ -45,15 +45,14 @@ def test_thumbnail_lookuptable(input_uint8_tif_2: Path):
 
 
 def test_thumbnail_from_numpy_bitflag(input_uint8_tif: Path):
-    writer = FileWrite()
     outfile = Path(tempfile.gettempdir()) / "test-bitflag.jpg"
     water = 128
 
     with rasterio.open(input_uint8_tif) as ds:
-        input_geobox = GridSpec.from_rio(ds)
+        input_geobox = GeoBox.from_rio(ds)
         data = ds.read(1)
 
-        image_bytes = writer.create_thumbnail_singleband_from_numpy(
+        image_bytes = create_thumbnail_singleband_from_numpy(
             input_data=data, input_geobox=input_geobox, bit=water
         )
 
@@ -64,7 +63,6 @@ def test_thumbnail_from_numpy_bitflag(input_uint8_tif: Path):
 
 
 def test_thumbnail_from_numpy_lookuptable(input_uint8_tif_2: Path):
-    writer = FileWrite()
     outfile = Path(tempfile.gettempdir()) / "test-lookuptable.jpg"
     wofs_lookup = {
         0: [150, 150, 110],  # dry
@@ -79,10 +77,10 @@ def test_thumbnail_from_numpy_lookuptable(input_uint8_tif_2: Path):
     }
 
     with rasterio.open(input_uint8_tif_2) as ds:
-        input_geobox = GridSpec.from_rio(ds)
+        input_geobox = GeoBox.from_rio(ds)
         data = ds.read(1)
 
-        image_bytes = writer.create_thumbnail_singleband_from_numpy(
+        image_bytes = create_thumbnail_singleband_from_numpy(
             input_data=data, input_geobox=input_geobox, lookup_table=wofs_lookup
         )
 


### PR DESCRIPTION
As part of ODC 1.9 integration, we want to shift towards using `odc-geo` where possible.
Replace the COG writing code implemented here with the logic from `odc-geo` - this removes the need for the `FileWrite` and `GridSpec` classes. 