### PR TITLE
Remove distutils replace with shutils

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,7 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/eodatasets3
-    steps: 
+    steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -30,4 +30,3 @@ jobs:
         with:
           user: "__token__"
           password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/eodatasets3/verify.py
+++ b/eodatasets3/verify.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 import os
 import typing
-from distutils import spawn
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -35,11 +34,14 @@ def find_exe(name: str):
     :return: the absolute path to the executable.
     :rtype: str
     """
-    executable = spawn.find_executable(name)
-    if not executable:
-        raise Exception(f"No {name!r} command found.")
+    from shutil import which
 
-    return executable
+    executable = which(name)
+
+    if executable is None:
+        raise Exception(f"No {name!r} command found.")
+    else:
+        return executable
 
 
 def calculate_file_sha1(filename):


### PR DESCRIPTION
As of Python 3.12, `distutils` has been removed.

This change replaces the `distutils.spawn.find_executable` with `shutils.which`.