### PR TITLE
add Sentinel-2C to abbreviations

### DIFF
--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -108,6 +108,7 @@ class LazyPlatformAbbreviation:
         "sentinel-1b": "s1b",
         "sentinel-2a": "s2a",
         "sentinel-2b": "s2b",
+        "sentinel-2c": "s2c",
         "aqua": "aqu",
         "terra": "ter",
     }


### PR DESCRIPTION
Apparently, this is the only change needed to enable Sentinel-2C packaging.