### PR TITLE
dependabot: update boto* weekly instead

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,27 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/requirements"
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "daily"
     groups:
-      pip-deps:
+      uv-deps:
         patterns:
           - "*"
+        exclude-patterns: # Packages updated almost every day.
+          - "boto3"
+          - "botocore"
+  - package-ecosystem: "uv"
+    # Have two jobs with same eco-system/directory by setting target-branch
+    # for one of them:
+    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+    target-branch: "develop"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      uv-weekly-deps:
+        patterns:
+          - "boto3"
+          - "botocore"


### PR DESCRIPTION
Their release schedule is almost daily,
so update them once a week.