### PR TITLE
Unpin pystac

### DIFF
--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -313,6 +313,7 @@ _DERIVATIVE_PRODUCT_PROPS = {
 _STAC_MISC_PROPS = {
     "providers": None,  # https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md#provider,
     # Projection extension
+    "proj:code": str,
     "proj:epsg": int,
     "proj:shape": None,
     "proj:transform": None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "xarray",
     "datacube>=1.9.0",
     "python-rapidjson",
-    "pystac>=1.8.4,<1.12",
+    "pystac>=1.8.4",
 ]
 
 [project.urls]
@@ -67,6 +67,7 @@ all = [
     "deepdiff>=8.0",
     "h5py", # From wagl (and core)
     "mock",
+    "pystac>=1.12",
     "pytest-cov",
     "pytest-xdist",
     "pytest",
@@ -81,6 +82,7 @@ test = [
     "deepdiff>=8.0",
     "h5py", # From wagl (and core)
     "mock",
+    "pystac>=1.12",
     "pytest-cov",
     "pytest-xdist",
     "pytest",

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -76,6 +76,8 @@ deprecat==2.1.3
     # via datacube
 distributed==2025.4.1
     # via datacube
+exceptiongroup==1.2.2
+    # via cattrs
 fiona==1.10.1
     # via eodatasets3 (pyproject.toml)
 fsspec==2025.3.2
@@ -86,6 +88,8 @@ greenlet==3.2.1
     # via sqlalchemy
 h5py==3.13.0
     # via eodatasets3 (pyproject.toml)
+importlib-metadata==8.7.0
+    # via dask
 jinja2==3.1.6
     # via distributed
 jmespath==1.0.1
@@ -149,7 +153,7 @@ pyproj==3.7.1
     #   eodatasets3 (pyproject.toml)
     #   datacube
     #   odc-geo
-pystac==1.11.0
+pystac==1.13.0
     # via eodatasets3 (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
@@ -218,8 +222,10 @@ tornado==6.4.2
 typing-extensions==4.13.2
     # via
     #   alembic
+    #   cattrs
     #   referencing
     #   sqlalchemy
+    #   structlog
 tzdata==2025.2
     # via pandas
 urllib3==2.4.0
@@ -234,3 +240,5 @@ xarray==2025.3.1
     #   datacube
 zict==3.0.0
     # via distributed
+zipp==3.21.0
+    # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -100,6 +100,10 @@ docutils==0.21.2
     # via
     #   sphinx
     #   sphinx-rtd-theme
+exceptiongroup==1.2.2
+    # via
+    #   cattrs
+    #   pytest
 execnet==2.1.1
     # via pytest-xdist
 fiona==1.10.1
@@ -118,6 +122,8 @@ imageio==2.37.0
     # via scikit-image
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==8.7.0
+    # via dask
 iniconfig==2.1.0
     # via pytest
 jinja2==3.1.6
@@ -221,7 +227,7 @@ pyproj==3.7.1
     #   datacube
     #   morecantile
     #   odc-geo
-pystac==1.11.0
+pystac==1.13.0
     # via eodatasets3 (pyproject.toml)
 pytest==8.3.5
     # via
@@ -326,6 +332,11 @@ tblib==3.1.0
     # via distributed
 tifffile==2025.3.30
     # via scikit-image
+tomli==2.2.1
+    # via
+    #   coverage
+    #   pytest
+    #   sphinx
 toolz==1.0.0
     # via
     #   dask
@@ -337,10 +348,12 @@ tornado==6.4.2
 typing-extensions==4.13.2
     # via
     #   alembic
+    #   cattrs
     #   pydantic
     #   pydantic-core
     #   referencing
     #   sqlalchemy
+    #   structlog
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
@@ -359,3 +372,5 @@ xarray==2025.3.1
     #   datacube
 zict==3.0.0
     # via distributed
+zipp==3.21.0
+    # via importlib-metadata

--- a/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
+++ b/tests/integration/data/tostac/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item_expected.json
@@ -1,6 +1,6 @@
 {
   "type": "Feature",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "id": "2aa69fcf-aa55-4747-9d95-3652f9fe79b0",
   "properties": {
       "title": "ga_ls8c_ard_3-1-0_088080_2020-05-25_final",
@@ -57,7 +57,7 @@
               "b5f234fe-bba8-5483-9bc0-250360d429cf"
           ]
       },
-      "proj:epsg": 32656,
+      "proj:code": "EPSG:32656",
       "proj:shape": [
           7841, 
           7781
@@ -209,7 +209,7 @@
                   "name": "nbar_blue"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -238,7 +238,7 @@
                   "name": "nbar_coastal_aerosol"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -267,7 +267,7 @@
                   "name": "nbar_green"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -296,7 +296,7 @@
                   "name": "nbar_nir"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -325,7 +325,7 @@
                   "name": "nbar_panchromatic"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               15681,
               15561
@@ -354,7 +354,7 @@
                   "name": "nbar_red"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -383,7 +383,7 @@
                   "name": "nbar_swir_1"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -412,7 +412,7 @@
                   "name": "nbar_swir_2"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -441,7 +441,7 @@
                   "name": "nbart_blue"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -470,7 +470,7 @@
                   "name": "nbart_coastal_aerosol"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -499,7 +499,7 @@
                   "name": "nbart_green"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -528,7 +528,7 @@
                   "name": "nbart_nir"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -557,7 +557,7 @@
                   "name": "nbart_panchromatic"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               15681,
               15561
@@ -586,7 +586,7 @@
                   "name": "nbart_red"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -615,7 +615,7 @@
                   "name": "nbart_swir_1"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -644,7 +644,7 @@
                   "name": "nbart_swir_2"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -673,7 +673,7 @@
                   "name": "oa_azimuthal_exiting"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -702,7 +702,7 @@
                   "name": "oa_azimuthal_incident"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -731,7 +731,7 @@
                   "name": "oa_combined_terrain_shadow"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -760,7 +760,7 @@
                   "name": "oa_exiting_angle"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -789,7 +789,7 @@
                   "name": "oa_fmask"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -818,7 +818,7 @@
                   "name": "oa_incident_angle"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -847,7 +847,7 @@
                   "name": "oa_nbar_contiguity"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -876,7 +876,7 @@
                   "name": "oa_nbart_contiguity"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -905,7 +905,7 @@
                   "name": "oa_relative_azimuth"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -934,7 +934,7 @@
                   "name": "oa_relative_slope"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -963,7 +963,7 @@
                   "name": "oa_satellite_azimuth"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -992,7 +992,7 @@
                   "name": "oa_satellite_view"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -1021,7 +1021,7 @@
                   "name": "oa_solar_azimuth"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -1050,7 +1050,7 @@
                   "name": "oa_solar_zenith"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -1079,7 +1079,7 @@
                   "name": "oa_time_delta"
               }
           ],
-          "proj:epsg": 32656,
+          "proj:code": "EPSG:32656",
           "proj:shape": [
               7841,
               7781
@@ -1138,7 +1138,7 @@
   ],
   "stac_extensions": [
       "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-      "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+      "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
       "https://stac-extensions.github.io/view/v1.0.0/schema.json"
   ],
   "collection": "ga_ls8c_ard_3"

--- a/tests/integration/test_tostac.py
+++ b/tests/integration/test_tostac.py
@@ -61,10 +61,10 @@ def test_tostac_no_grids(odc_dataset_path: Path, expected_stac_doc: dict) -> Non
 
     # No longer expect proj  fields (they come from grids).
     remove_stac_properties(
-        expected_stac_doc, ("proj:shape", "proj:transform", "proj:epsg")
+        expected_stac_doc, ("proj:shape", "proj:transform", "proj:code")
     )
     # But we do still expect a global CRS.
-    expected_stac_doc["properties"]["proj:epsg"] = 32656
+    expected_stac_doc["properties"]["proj:code"] = "EPSG:32656"
 
     output_doc = json.load(expected_output_path.open())
     assert_same(expected_stac_doc, output_doc)

--- a/uv.lock
+++ b/uv.lock
@@ -574,6 +574,7 @@ all = [
     { name = "h5py" },
     { name = "mock" },
     { name = "netcdf4" },
+    { name = "pystac" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -597,6 +598,7 @@ test = [
     { name = "h5py" },
     { name = "mock" },
     { name = "netcdf4" },
+    { name = "pystac" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -657,7 +659,9 @@ requires-dist = [
     { name = "netcdf4", marker = "extra == 'test'" },
     { name = "numpy", specifier = ">=1.15.4" },
     { name = "pyproj" },
-    { name = "pystac", specifier = ">=1.8.4,<1.12" },
+    { name = "pystac", specifier = ">=1.8.4" },
+    { name = "pystac", marker = "extra == 'all'", specifier = ">=1.12" },
+    { name = "pystac", marker = "extra == 'test'", specifier = ">=1.12" },
     { name = "pytest", marker = "extra == 'all'" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'all'" },
@@ -1594,14 +1598,14 @@ wheels = [
 
 [[package]]
 name = "pystac"
-version = "1.11.0"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/4f/f6f89956aabffd1211fa9c9130293ac67f774c66fab7944bfe33dc317f18/pystac-1.11.0.tar.gz", hash = "sha256:acb1e04be398a0cda2d8870ab5e90457783a8014a206590233171d8b2ae0d9e7", size = 141392, upload-time = "2024-10-03T19:54:32.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/52/a2f882be13f3947f4e3330d59926d844f3a9c2eb07e1391c3f90ab4653eb/pystac-1.13.0.tar.gz", hash = "sha256:9e5d908a390eed800228a956d7f3577c8f0cbac49806aaa0b14b7c4e06520b8c", size = 162558, upload-time = "2025-04-15T18:14:09.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/5b/60dc94cbf6af2fd3a3d3fae52de7e294819af2dfe7a1bea4d246beb7e0b6/pystac-1.11.0-py3-none-any.whl", hash = "sha256:10ac7c7b4ea6c5ec8333829a09ec1a33b596f02d1a97ffbbd72cd1b6c10598c1", size = 183925, upload-time = "2024-10-03T19:54:30.751Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/1b361a24d3087cd922ec1f6dfe02f230507d800ada3f922532f1f906a09e/pystac-1.13.0-py3-none-any.whl", hash = "sha256:fa22cc04e58bbbc22c8d049e715a37ab803802d8d1334afc48e6eab64c5946e4", size = 206821, upload-time = "2025-04-15T18:14:07.855Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Unpin pystac version and update
the expected file in tests for
the latest version. Add a version
constraint to the test groups so
that tests use a sufficiently
recent pystac version.