### PR TITLE
Publish releases from GHA with OIDC Auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+---
+name: Build & upload PyPI package
+
+on:
+  push:
+    branches: [develop]
+    tags: ["*"]
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    environment: pypi
+    if: github.repository_owner == 'opendatacube' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+        # This defaults to OIDC identification between GitHub and PyPI
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -399,25 +399,11 @@ Note that this will run pip-compile _inside_ the docker container for maximum co
 
 ## Creating Releases
 
-First, draft [some release notes](https://github.com/opendatacube/eo-datasets/releases)
-for users of the library.
+Create a [new release within GitHub](https://github.com/opendatacube/eo-datasets/releases).
 
-Now tag and upload:
+Specify a new tag name similar to `eodatasets3-1.9.2` replacing 1.9.2 with the new version number.
 
-```
-# Be up-to-date.
-git fetch origin
+Publish the release.
 
-# Create a tag for the new version
-# (using semantic versioning https://semver.org/)
-git tag eodatasets3-<version> origin/eodatasets3
+GitHub Actions will build the release, and upload it to [PyPI](https://pypi.org/project/eodatasets3/).
 
-# Create package
-python3 setup.py sdist bdist_wheel
-
-# Upload it (Jeremy, Damien, Kirill have pypi ownership)
-python3 -m twine upload  dist/*
-
-# Push tag to main repository
-git push origin --tags
-```

--- a/README.md
+++ b/README.md
@@ -406,4 +406,3 @@ Specify a new tag name similar to `eodatasets3-1.9.2` replacing 1.9.2 with the n
 Publish the release.
 
 GitHub Actions will build the release, and upload it to [PyPI](https://pypi.org/project/eodatasets3/).
-


### PR DESCRIPTION
Add a new GitHub Actions workflow to build packages on every push to `develop`, our main development branch, and to Publish to PyPI when a new GitHub Release is created.

Also update the release instructions in the readme.

This should be a simpler, faster, easier and more secure way to create releases.

This repository is set as a Trusted Publisher for [this project on PyPI](https://pypi.org/project/eodatasets3/):

![image](https://github.com/user-attachments/assets/ba056195-1eb3-4be6-9506-adc85a8aa1dd)

The included workflow uses the "PyPI" [deployment environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) which PyPI is requiring.