### PR TITLE
python-rapidjson is only required for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "structlog",
     "xarray",
     "datacube>=1.9.0",
-    "python-rapidjson",
     "pystac>=1.8.4",
 ]
 
@@ -103,6 +102,7 @@ dev = [
     "netcdf4>=1.7.2",
     "pytest>=8.3.5",
     "pytest-cov>=6.1.1",
+    "python-rapidjson",
     "pytest-xdist>=3.6.1",
     "rio-cogeo>=5.4.1",
     "ruff>=0.11.8",

--- a/tests/common.py
+++ b/tests/common.py
@@ -226,5 +226,9 @@ def dump_roundtrip(generated_doc):
     is identical once produced.
     """
     return rapidjson.loads(
-        rapidjson.dumps(generated_doc, datetime_mode=True, uuid_mode=True)
+        rapidjson.dumps(
+            generated_doc,
+            datetime_mode=rapidjson.DM_ISO8601 | rapidjson.DM_SHIFT_TO_UTC,
+            uuid_mode=rapidjson.UM_CANONICAL,
+        )
     )


### PR DESCRIPTION
Also fix the arguments `rapidjson` is being called with.

- [x] This requires #418 first.