### PR TITLE
Upgrade to ruamel.yaml 0.18+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy>=1.15.4",
     "pyproj",
     "rasterio",
-    "ruamel.yaml<0.18", # Pinning as per original, although >=0.18 is the latest
+    "ruamel.yaml",
     "scipy",
     "shapely",
     "structlog",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -185,7 +185,7 @@ def expected_l1_ls8_folder(
     org_code = organisation.split(".")[0]
     product_name = f"{org_code}_ls8c_level1_{collection}"
     if collection == "2":
-        processing_datetime = datetime(2020, 9, 7, 19, 30, 5)
+        processing_datetime = datetime(2020, 9, 7, 19, 30, 5, tzinfo=UTC)
         cloud_cover = 93.28
         points_model = 125
         points_version = 5
@@ -195,7 +195,7 @@ def expected_l1_ls8_folder(
         uuid = "d9221c40-24c3-5356-ab22-4dcac2bf2d70"
         quality_tag = "QA_PIXEL"
     else:
-        processing_datetime = datetime(2017, 4, 5, 11, 17, 36)
+        processing_datetime = datetime(2017, 4, 5, 11, 17, 36, tzinfo=UTC)
         cloud_cover = 93.22
         points_model = 66
         points_version = 4
@@ -214,7 +214,7 @@ def expected_l1_ls8_folder(
             "href": f"https://collections.dea.ga.gov.au/product/{product_name}",
         },
         "properties": {
-            "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435),
+            "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435, tzinfo=UTC),
             # The minor version comes from the processing date (as used in filenames to distinguish reprocesses).
             "odc:dataset_version": f"{collection}.0.{processing_date}",
             "odc:file_format": "GeoTIFF",
@@ -393,10 +393,10 @@ def l1_ls7_tarball_md_expected(
         },
         "crs": "epsg:32652",
         "properties": {
-            "datetime": datetime(2013, 4, 29, 1, 10, 20, 336_104),
+            "datetime": datetime(2013, 4, 29, 1, 10, 20, 336_104, tzinfo=UTC),
             "odc:dataset_version": "1.0.20161124",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": datetime(2016, 11, 24, 8, 26, 33),
+            "odc:processing_datetime": datetime(2016, 11, 24, 8, 26, 33, tzinfo=UTC),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level1",
             "odc:region_code": "104078",
@@ -554,10 +554,10 @@ def l1_ls5_tarball_md_expected(
         },
         "crs": "epsg:32655",
         "properties": {
-            "datetime": datetime(1997, 4, 6, 23, 17, 43, 102_000),
+            "datetime": datetime(1997, 4, 6, 23, 17, 43, 102_000, tzinfo=UTC),
             "odc:dataset_version": "1.0.20161231",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": datetime(2016, 12, 31, 15, 54, 58),
+            "odc:processing_datetime": datetime(2016, 12, 31, 15, 54, 58, tzinfo=UTC),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level1",
             "odc:region_code": "090085",

--- a/tests/integration/prepare/test_prepare_landsat_l1.py
+++ b/tests/integration/prepare/test_prepare_landsat_l1.py
@@ -1,6 +1,6 @@
 import shutil
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -176,7 +176,7 @@ def test_prepare_l8_l1_c2(tmp_path: Path, l1_c2_ls8_folder: Path) -> None:
             ),
         },
         "properties": {
-            "datetime": "2022-05-06T23:39:59.285133",
+            "datetime": datetime.fromisoformat("2022-05-06T23:39:59.285133Z"),
             "eo:cloud_cover": 86.35,
             "eo:gsd": 15.0,
             "eo:instrument": "OLI_TIRS",
@@ -194,7 +194,7 @@ def test_prepare_l8_l1_c2(tmp_path: Path, l1_c2_ls8_folder: Path) -> None:
             "landsat:wrs_row": 74,
             "odc:dataset_version": "2.0.20220512",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": "2022-05-12T14:00:17",
+            "odc:processing_datetime": datetime.fromisoformat("2022-05-12T14:00:17Z"),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level1",
             "odc:region_code": "089074",
@@ -324,7 +324,7 @@ def l9_expected():
             },
         },
         "properties": {
-            "datetime": "2022-02-09T02:05:18.736033",
+            "datetime": datetime.fromisoformat("2022-02-09T02:05:18.736033Z"),
             "eo:cloud_cover": 0.12,
             "eo:gsd": 15.0,
             "eo:instrument": "OLI_TIRS",
@@ -346,7 +346,7 @@ def l9_expected():
             "landsat:wrs_row": 81,
             "odc:dataset_version": "2.0.20220209",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": "2022-02-09T04:08:31",
+            "odc:processing_datetime": datetime.fromisoformat("2022-02-09T04:08:31Z"),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level1",
             "odc:region_code": "112081",
@@ -626,7 +626,7 @@ def expected_lc08_l2_c2_post_20210507_folder(
     """ """
     org_code = organisation.split(".")[0]
     product_name = f"{org_code}_ls8c_level{leveln_collection}_{collection}"
-    processing_datetime = datetime(2021, 5, 8, 11, 5, 47)
+    processing_datetime = datetime(2021, 5, 8, 11, 5, 47, tzinfo=UTC)
     processing_date = processing_datetime.strftime("%Y%m%d")
     return {
         "$schema": "https://schemas.opendatacube.org/dataset",
@@ -637,7 +637,7 @@ def expected_lc08_l2_c2_post_20210507_folder(
             "href": f"https://collections.dea.ga.gov.au/product/{product_name}",
         },
         "properties": {
-            "datetime": datetime(2021, 5, 3, 0, 39, 15, 718295),
+            "datetime": datetime(2021, 5, 3, 0, 39, 15, 718295, tzinfo=UTC),
             # The minor version comes from the processing date,
             # as used in filenames to distinguish reprocesses.
             "odc:dataset_version": f"{collection}.0.{processing_date}",
@@ -841,12 +841,12 @@ def expected_lt05_l2_c2_folder():
             "href": "https://collections.dea.ga.gov.au/product/usgs_ls5t_level2_2",
         },
         "properties": {
-            "datetime": datetime(1998, 3, 8, 23, 26, 47, 294081),
+            "datetime": datetime(1998, 3, 8, 23, 26, 47, 294081, tzinfo=UTC),
             # The minor version comes from the processing date,
             # as used in filenames to distinguish reprocesses.
             "odc:dataset_version": "2.0.20200909",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": (datetime(2020, 9, 9, 10, 36, 59)),
+            "odc:processing_datetime": datetime(2020, 9, 9, 10, 36, 59, tzinfo=UTC),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level2",
             "odc:region_code": "090084",
@@ -967,12 +967,12 @@ def expected_le07_l2_c2_folder():
             "href": "https://collections.dea.ga.gov.au/product/usgs_ls7e_level2_2",
         },
         "properties": {
-            "datetime": datetime(2021, 3, 31, 23, 1, 59, 738020),
+            "datetime": datetime(2021, 3, 31, 23, 1, 59, 738020, tzinfo=UTC),
             # The minor version comes from the processing date,
             # as used in filenames to distinguish reprocesses.
             "odc:dataset_version": "2.0.20210426",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": (datetime(2021, 4, 26, 10, 52, 29)),
+            "odc:processing_datetime": datetime(2021, 4, 26, 10, 52, 29, tzinfo=UTC),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level2",
             "odc:region_code": "090084",
@@ -1156,7 +1156,7 @@ def expected_le07_l1_c2_folder():
             },
         },
         "properties": {
-            "datetime": "2022-03-10T00:09:40.814477",
+            "datetime": datetime.fromisoformat("2022-03-10T00:09:40.814477Z"),
             "eo:cloud_cover": 5.0,
             "eo:gsd": 15.0,
             "eo:instrument": "ETM",
@@ -1178,7 +1178,7 @@ def expected_le07_l1_c2_folder():
             "landsat:wrs_row": 68,
             "odc:dataset_version": "2.0.20220405",
             "odc:file_format": "GeoTIFF",
-            "odc:processing_datetime": "2022-04-05T10:37:54",
+            "odc:processing_datetime": datetime.fromisoformat("2022-04-05T10:37:54Z"),
             "odc:producer": "usgs.gov",
             "odc:product_family": "level1",
             "odc:region_code": "107068",

--- a/tests/integration/prepare/test_prepare_sentinel_l1.py
+++ b/tests/integration/prepare/test_prepare_sentinel_l1.py
@@ -1,6 +1,6 @@
 import copy
-import datetime
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -231,7 +231,7 @@ ESA_EXPECTED_METADATA = {
     },
     "product": {"name": "esa_s2bm_level1_0"},
     "properties": {
-        "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
+        "datetime": datetime(2020, 10, 11, 0, 6, 49, 882566, tzinfo=UTC),
         "eo:cloud_cover": 24.9912,
         "eo:gsd": 10,
         "eo:instrument": "MSI",
@@ -241,7 +241,7 @@ ESA_EXPECTED_METADATA = {
         "eo:sun_elevation": 37.3713908882192,
         "odc:dataset_version": "0.0.20201011",
         "odc:file_format": "JPEG2000",
-        "odc:processing_datetime": datetime.datetime(2020, 10, 11, 1, 47, 4, 112949),
+        "odc:processing_datetime": datetime(2020, 10, 11, 1, 47, 4, 112949, tzinfo=UTC),
         "odc:producer": "esa.int",
         "odc:product_family": "level1",
         "odc:region_code": "55HFA",
@@ -251,7 +251,9 @@ ESA_EXPECTED_METADATA = {
         "sentinel:datatake_type": "INS-NOBS",
         "sat:orbit_state": "descending",
         "sat:relative_orbit": 30,
-        "sentinel:datatake_start_datetime": datetime.datetime(2020, 10, 11, 1, 14, 46),
+        "sentinel:datatake_start_datetime": datetime(
+            2020, 10, 11, 1, 14, 46, tzinfo=UTC
+        ),
         "sentinel:processing_baseline": "02.09",
         "sentinel:processing_center": "EPAE",
         "sentinel:reception_station": "EDRS",
@@ -363,7 +365,7 @@ SINERGISE_EXPECTED_METADATA = {
         },
     },
     "properties": {
-        "datetime": datetime.datetime(2020, 10, 11, 0, 6, 49, 882566),
+        "datetime": datetime(2020, 10, 11, 0, 6, 49, 882566, tzinfo=UTC),
         "eo:cloud_cover": 24.9912,
         "eo:gsd": 10,
         "eo:instrument": "MSI",
@@ -373,7 +375,7 @@ SINERGISE_EXPECTED_METADATA = {
         "eo:sun_elevation": 37.3713908882192,
         "odc:dataset_version": "0.0.20201011",
         "odc:file_format": "JPEG2000",
-        "odc:processing_datetime": datetime.datetime(2020, 10, 11, 1, 47, 4, 112949),
+        "odc:processing_datetime": datetime(2020, 10, 11, 1, 47, 4, 112949, tzinfo=UTC),
         "odc:producer": "sinergise.com",
         "odc:product_family": "level1",
         "odc:region_code": "55HFA",
@@ -383,7 +385,9 @@ SINERGISE_EXPECTED_METADATA = {
         "sinergise_product_id": "73e1a409-595d-4fbf-8fe0-01e0ee26bf00",
         "sentinel:product_name": "S2B_MSIL1C_20201011T000249_N0209_R030_T55HFA_20201011T011446",
         "sentinel:datastrip_id": "S2B_OPER_MSI_L1C_DS_EPAE_20201011T011446_S20201011T000244_N02.09",
-        "sentinel:datatake_start_datetime": datetime.datetime(2020, 10, 11, 1, 14, 46),
+        "sentinel:datatake_start_datetime": datetime(
+            2020, 10, 11, 1, 14, 46, tzinfo=UTC
+        ),
         "sentinel:sentinel_tile_id": "S2B_OPER_MSI_L1C_TL_EPAE_20201011T011446_A018789_T55HFA_N02.09",
     },
     "accessories": {
@@ -755,7 +759,7 @@ def test_run_unusual_multigranule(tmp_path: Path) -> None:
                 }
             },
             "properties": {
-                "datetime": "2016-01-29T01:00:47.667000",
+                "datetime": datetime.fromisoformat("2016-01-29T01:00:47.667000Z"),
                 "eo:cloud_cover": 18.0896,
                 "eo:constellation": "sentinel-2",
                 "eo:gsd": 10,
@@ -765,14 +769,18 @@ def test_run_unusual_multigranule(tmp_path: Path) -> None:
                 "eo:sun_elevation": 31.56054447161,
                 "odc:dataset_version": "0.0.20160209",
                 "odc:file_format": "JPEG2000",
-                "odc:processing_datetime": "2016-02-09T14:32:42.340511",
+                "odc:processing_datetime": datetime.fromisoformat(
+                    "2016-02-09T14:32:42.340511Z"
+                ),
                 "odc:producer": "esa.int",
                 "odc:product_family": "level1",
                 "odc:region_code": "53JMH",
                 "sat:orbit_state": "descending",
                 "sat:relative_orbit": 2,
                 "sentinel:datastrip_id": "S2A_OPER_MSI_L1C_DS_MTI__20160209T133001_S20160129T010047_N02.01",
-                "sentinel:datatake_start_datetime": "2016-02-09T13:30:01",
+                "sentinel:datatake_start_datetime": datetime.fromisoformat(
+                    "2016-02-09T13:30:01Z"
+                ),
                 "sentinel:datatake_type": "INS-NOBS",
                 "sentinel:processing_baseline": "02.01",
                 "sentinel:processing_center": "MTI_",

--- a/tests/integration/test_assemble.py
+++ b/tests/integration/test_assemble.py
@@ -5,7 +5,7 @@ Some features are testsed in other sibling test files, such as alternative
 naming conventions.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from pprint import pprint
 from textwrap import dedent
@@ -143,11 +143,13 @@ def test_dea_style_package(
                 "ones": {"path": "ga_ls8c_ones_3-0-0_090084_2016-01-21_final_ones.tif"},
             },
             "properties": {
-                "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435),
+                "datetime": datetime(2016, 1, 21, 23, 50, 23, 54435, tzinfo=UTC),
                 "dea:dataset_maturity": "final",
                 "odc:dataset_version": "3.0.0",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": "2016-03-04T14:23:30",
+                "odc:processing_datetime": datetime.fromisoformat(
+                    "2016-03-04T14:23:30Z"
+                ),
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "ones",
                 # The remaining fields were inherited from the source dataset

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -1,7 +1,7 @@
 import operator
 import uuid
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -176,16 +176,20 @@ def test_s2_naming_conventions(tmp_path: Path) -> None:
                 "name": "ga_s2am_blueberries_1",
             },
             "properties": {
-                "datetime": datetime(2018, 11, 4, 0, 0),
+                "datetime": datetime(2018, 11, 4, 0, 0, tzinfo=UTC),
                 "eo:instrument": "msi",
                 "eo:platform": "sentinel-2a",
                 "odc:dataset_version": "1.0.0",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": datetime(2018, 11, 5, 12, 23, 23),
+                "odc:processing_datetime": datetime(
+                    2018, 11, 5, 12, 23, 23, tzinfo=UTC
+                ),
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "blueberries",
                 "odc:region_code": "Oz",
-                "sentinel:datatake_start_datetime": datetime(2017, 8, 22, 1, 56, 26),
+                "sentinel:datatake_start_datetime": datetime(
+                    2017, 8, 22, 1, 56, 26, tzinfo=UTC
+                ),
                 "sentinel:sentinel_tile_id": "S2A_OPER_MSI_L1C_TL_SGS__20170822T015626_A011310_T54KYU_N02.05",
             },
             "lineage": {

--- a/tests/integration/test_packagewagl.py
+++ b/tests/integration/test_packagewagl.py
@@ -1,7 +1,7 @@
 import warnings
 from binascii import crc32
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from pprint import pprint
 from textwrap import indent
@@ -209,10 +209,14 @@ def test_whole_landsat_wagl_package(
                 },
             },
             "properties": {
-                "datetime": datetime(2016, 6, 28, 0, 2, 28, 624_635),
+                "datetime": datetime(2016, 6, 28, 0, 2, 28, 624_635, tzinfo=UTC),
                 "dea:dataset_maturity": "final",
-                "dtr:end_datetime": datetime(2016, 6, 28, 0, 2, 43, 114_771),
-                "dtr:start_datetime": datetime(2016, 6, 28, 0, 2, 14, 25815),
+                "dtr:end_datetime": datetime(
+                    2016, 6, 28, 0, 2, 43, 114_771, tzinfo=UTC
+                ),
+                "dtr:start_datetime": datetime(
+                    2016, 6, 28, 0, 2, 14, 25815, tzinfo=UTC
+                ),
                 "eo:cloud_cover": 63.069_613_577_531_236,
                 "eo:gsd": 1490.480_769_230_769_3,
                 "eo:instrument": "OLI_TIRS",
@@ -251,7 +255,9 @@ def test_whole_landsat_wagl_package(
                 "landsat:wrs_row": 84,
                 "odc:dataset_version": "3.2.1",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": datetime(2019, 7, 11, 23, 29, 29, 21245),
+                "odc:processing_datetime": datetime(
+                    2019, 7, 11, 23, 29, 29, 21245, tzinfo=UTC
+                ),
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "ard",
                 "odc:region_code": "092084",
@@ -855,7 +861,7 @@ def test_esa_sentinel_wagl_package(tmp_path: Path) -> None:
                 },
             },
             "properties": {
-                "datetime": "2020-10-31T00:55:10.954414",
+                "datetime": datetime.fromisoformat("2020-10-31T00:55:10.954414Z"),
                 "dea:dataset_maturity": "final",
                 "eo:cloud_cover": 11.063428320692061,
                 "eo:gsd": 998.1818181818181,
@@ -891,7 +897,9 @@ def test_esa_sentinel_wagl_package(tmp_path: Path) -> None:
                 "gqa:stddev_y": 1.9,
                 "odc:dataset_version": "3.2.1",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": "2021-02-10T03:25:22.635668",
+                "odc:processing_datetime": datetime.fromisoformat(
+                    "2021-02-10T03:25:22.635668Z"
+                ),
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "ard",
                 "odc:region_code": "53JQJ",
@@ -900,7 +908,9 @@ def test_esa_sentinel_wagl_package(tmp_path: Path) -> None:
                 "sentinel:datastrip_id": "S2A_OPER_MSI_L1C_DS_EPAE_20201031T022859_S20201031T004711_N02.09",
                 "sentinel:sentinel_tile_id": "S2A_OPER_MSI_L1C_TL_EPAE_20201031T022859_A027984_T53JQJ_N02.09",
                 "sentinel:product_name": "S2A_MSIL1C_20201031T004711_N0209_R102_T53JQJ_20201031T022859",
-                "sentinel:datatake_start_datetime": "2020-10-31T02:28:59",
+                "sentinel:datatake_start_datetime": datetime.fromisoformat(
+                    "2020-10-31T02:28:59Z"
+                ),
             },
             "measurements": {
                 "nbar_blue": {
@@ -1286,7 +1296,7 @@ def test_sinergise_sentinel_wagl_package(tmp_path: Path) -> None:
                 },
             },
             "properties": {
-                "datetime": "2021-04-25T23:54:23.437224",
+                "datetime": datetime.fromisoformat("2021-04-25T23:54:23.437224Z"),
                 "dea:dataset_maturity": "final",
                 "eo:cloud_cover": 2.7936189093810837,
                 "eo:gsd": 998.1818181818181,
@@ -1322,12 +1332,16 @@ def test_sinergise_sentinel_wagl_package(tmp_path: Path) -> None:
                 "gqa:stddev_y": 0.32,
                 "odc:dataset_version": "3.2.1",
                 "odc:file_format": "GeoTIFF",
-                "odc:processing_datetime": "2021-05-21T07:51:09.439427",
+                "odc:processing_datetime": datetime.fromisoformat(
+                    "2021-05-21T07:51:09.439427Z"
+                ),
                 "odc:producer": "ga.gov.au",
                 "odc:product_family": "ard",
                 "odc:region_code": "56JMQ",
                 "sentinel:datastrip_id": "S2B_OPER_MSI_L1C_DS_VGS4_20210426T010904_S20210425T235239_N03.00",
-                "sentinel:datatake_start_datetime": "2021-04-26T01:09:04",
+                "sentinel:datatake_start_datetime": datetime.fromisoformat(
+                    "2021-04-26T01:09:04Z"
+                ),
                 "sentinel:grid_square": "MQ",
                 "sentinel:latitude_band": "J",
                 "sentinel:sentinel_tile_id": "S2B_OPER_MSI_L1C_TL_VGS4_20210426T010904_A021606_T56JMQ_N03.00",

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ requires-dist = [
     { name = "rasterio" },
     { name = "rio-cogeo", marker = "extra == 'all'" },
     { name = "rio-cogeo", marker = "extra == 'test'" },
-    { name = "ruamel-yaml", specifier = "<0.18" },
+    { name = "ruamel-yaml" },
     { name = "ruff", marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'test'" },
     { name = "scikit-image", marker = "extra == 'algorithms'" },
@@ -709,7 +709,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -897,7 +897,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
The change that was catching us out is whether plain timestamps are parsed to include a tzinfo (new) or not (old). This caused a lot of tests to fail. I've updated all the failing tests to expect datetimes WITH timezone, which will cause the tests to fail with old versions of ruamel.

eo-datasets itself was already comptible, and produces identical files with either version of ruamel.yaml.