### PR TITLE
Fix float serialisation code

### DIFF
--- a/eodatasets3/serialise.py
+++ b/eodatasets3/serialise.py
@@ -13,12 +13,10 @@ import click
 import jsonschema
 import numpy
 import shapely
-import shapely.affinity
-import shapely.ops
 from affine import Affine
 from datacube.model import SCHEMA_PATH as DATACUBE_SCHEMAS_PATH
 from datacube.utils import read_documents
-from ruamel.yaml import YAML, Representer
+from ruamel.yaml import YAML, Representer, RoundTripRepresenter
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
@@ -29,70 +27,82 @@ from eodatasets3.properties import FileFormat
 converter = cattr.Converter()
 
 
-def _format_representer(dumper, data: FileFormat):
-    return dumper.represent_scalar("tag:yaml.org,2002:str", f"{data.name}")
+class EODatasetsRepresentor(RoundTripRepresenter):
+    def format_representer(self, data: FileFormat):
+        return self.represent_scalar("tag:yaml.org,2002:str", f"{data.name}")
+
+    def uuid_representer(self, data):
+        """
+        :type data: uuid.UUID
+        :rtype: yaml.nodes.Node
+        """
+        return self.represent_scalar("tag:yaml.org,2002:str", f"{data}")
+
+    def represent_datetime(self, data: datetime):
+        """
+        The default Ruamel representer strips 'Z' suffixes for UTC.
+
+        But we like to be explicit.
+        """
+        # If there's a non-utc timezone, use it.
+        if data.tzinfo is not None and (data.utcoffset().total_seconds() > 0):
+            value = data.isoformat(" ")
+        else:
+            # Otherwise it's UTC (including when tz==null).
+            value = data.replace(tzinfo=None).isoformat(" ") + "Z"
+        return self.represent_scalar("tag:yaml.org,2002:timestamp", value)
+
+    def represent_numpy_datetime(self, data: numpy.datetime64):
+        return self.represent_datetime(data.astype("M8[ms]").tolist())
+
+    def represent_paths(self, data: PurePath):
+        return self.represent_str(data.as_posix())
+
+    def represent_float(self, data: float):
+        float_text = numpy.format_float_scientific(data)
+        return self.represent_scalar("tag:yaml.org,2002:float", float_text)
 
 
-def _uuid_representer(dumper, data):
-    """
-    :type dumper: yaml.representer.BaseRepresenter
-    :type data: uuid.UUID
-    :rtype: yaml.nodes.Node
-    """
-    return dumper.represent_scalar("tag:yaml.org,2002:str", f"{data}")
+EODatasetsRepresentor.add_representer(
+    FileFormat, EODatasetsRepresentor.format_representer
+)
+EODatasetsRepresentor.add_multi_representer(
+    UUID, EODatasetsRepresentor.uuid_representer
+)
+EODatasetsRepresentor.add_representer(
+    datetime, EODatasetsRepresentor.represent_datetime
+)
+EODatasetsRepresentor.add_multi_representer(
+    PurePath, EODatasetsRepresentor.represent_paths
+)
 
+# WAGL spits out many numpy primitives in docs.
+EODatasetsRepresentor.add_representer(numpy.int8, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.uint8, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.int16, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.uint16, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.int32, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.uint32, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.int64, Representer.represent_int)
+EODatasetsRepresentor.add_representer(numpy.uint64, Representer.represent_int)
+# Representer.represent_float is currently incompatible with numpy2 floats
+EODatasetsRepresentor.add_representer(
+    numpy.float32, EODatasetsRepresentor.represent_float
+)
+EODatasetsRepresentor.add_representer(
+    numpy.float64, EODatasetsRepresentor.represent_float
+)
+EODatasetsRepresentor.add_representer(float, EODatasetsRepresentor.represent_float)
 
-def _represent_datetime(self, data: datetime):
-    """
-    The default Ruamel representer strips 'Z' suffixes for UTC.
-
-    But we like to be explicit.
-    """
-    # If there's a non-utc timezone, use it.
-    if data.tzinfo is not None and (data.utcoffset().total_seconds() > 0):
-        value = data.isoformat(" ")
-    else:
-        # Otherwise it's UTC (including when tz==null).
-        value = data.replace(tzinfo=None).isoformat(" ") + "Z"
-    return self.represent_scalar("tag:yaml.org,2002:timestamp", value)
-
-
-def _represent_numpy_datetime(self, data: numpy.datetime64):
-    return _represent_datetime(self, data.astype("M8[ms]").tolist())
-
-
-def _represent_paths(self, data: PurePath):
-    return Representer.represent_str(self, data.as_posix())
-
-
-def _represent_float(self, data: float):
-    float_text = numpy.format_float_scientific(data)
-    return self.represent_scalar("tag:yaml.org,2002:float", float_text)
+EODatasetsRepresentor.add_representer(numpy.ndarray, Representer.represent_list)
+EODatasetsRepresentor.add_representer(
+    numpy.datetime64, EODatasetsRepresentor.represent_numpy_datetime
+)
 
 
 def _init_yaml() -> YAML:
     yaml = YAML()
-
-    yaml.representer.add_representer(FileFormat, _format_representer)
-    yaml.representer.add_multi_representer(UUID, _uuid_representer)
-    yaml.representer.add_representer(datetime, _represent_datetime)
-    yaml.representer.add_multi_representer(PurePath, _represent_paths)
-
-    # WAGL spits out many numpy primitives in docs.
-    yaml.representer.add_representer(numpy.int8, Representer.represent_int)
-    yaml.representer.add_representer(numpy.uint8, Representer.represent_int)
-    yaml.representer.add_representer(numpy.int16, Representer.represent_int)
-    yaml.representer.add_representer(numpy.uint16, Representer.represent_int)
-    yaml.representer.add_representer(numpy.int32, Representer.represent_int)
-    yaml.representer.add_representer(numpy.uint32, Representer.represent_int)
-    yaml.representer.add_representer(numpy.int64, Representer.represent_int)
-    yaml.representer.add_representer(numpy.uint64, Representer.represent_int)
-    # Representer.represent_float is currently incompatible with numpy2 floats
-    yaml.representer.add_representer(numpy.float32, _represent_float)
-    yaml.representer.add_representer(numpy.float64, _represent_float)
-
-    yaml.representer.add_representer(numpy.ndarray, Representer.represent_list)
-    yaml.representer.add_representer(numpy.datetime64, _represent_numpy_datetime)
+    yaml.Representer = EODatasetsRepresentor
 
     # Match yamllint default expectations. (Explicit start/end are recommended to tell if a file is cut off)
     yaml.width = 80
@@ -116,7 +126,6 @@ def dump_yaml(output_yaml: Path, *docs: Mapping) -> None:
 def dumps_yaml(stream, *docs: Mapping) -> None:
     """Dump yaml through a stream, using the default serialisation settings."""
     yml = _init_yaml()
-    yml.representer.add_representer(float, _represent_float)
     return yml.dump_all(docs, stream=stream)
 
 

--- a/tests/test_serialise.py
+++ b/tests/test_serialise.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from pathlib import Path
 
 from eodatasets3 import serialise
 
@@ -10,3 +11,12 @@ def test_dumps_yaml_scientific_notation() -> None:
     assert stream.getvalue().split()[3] == "7.e-06"
     assert stream.getvalue().split()[5] == "7.e-06"
     assert stream.getvalue().split()[7] == "8.e-06"
+
+
+def test_dump_yaml_scientific_notation(tmp_path: Path) -> None:
+    doc = {"response": [7e-06, 7e-06, 8e-06]}
+    output_file = tmp_path / "test.yaml"
+    serialise.dump_yaml(output_file, doc)
+    text = output_file.read_text()
+    assert "7.e-06" in text
+    assert "7e-06" not in text

--- a/uv.lock
+++ b/uv.lock
@@ -555,7 +555,6 @@ dependencies = [
     { name = "numpy" },
     { name = "pyproj" },
     { name = "pystac" },
-    { name = "python-rapidjson" },
     { name = "rasterio" },
     { name = "ruamel-yaml" },
     { name = "scipy" },
@@ -623,6 +622,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "python-rapidjson" },
     { name = "rio-cogeo" },
     { name = "ruff" },
     { name = "scikit-image" },
@@ -668,7 +668,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pytest-xdist", marker = "extra == 'all'" },
     { name = "pytest-xdist", marker = "extra == 'test'" },
-    { name = "python-rapidjson" },
     { name = "rasterio" },
     { name = "rio-cogeo", marker = "extra == 'all'" },
     { name = "rio-cogeo", marker = "extra == 'test'" },
@@ -699,6 +698,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "python-rapidjson" },
     { name = "rio-cogeo", specifier = ">=5.4.1" },
     { name = "ruff", specifier = ">=0.11.8" },
     { name = "scikit-image", specifier = ">=0.25.2" },
@@ -709,7 +709,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -897,7 +897,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
The way our custom YAML representation was being configured in _init_yml and dumps_yaml() was altering the global RoundTripRepresentor class in  ruamel.yaml. Anyone who used it after dumps_yaml() would get the fixed representation, but if it *hadn't* been called first you could get a representation of floats for small values that can't be understood by PyYAML.

This commit takes the correct way to customise YAML representation by creating a subclass and using that instead.

Fixes #415 