### PR TITLE
pre-commit: update ruff hook name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.12.5
       hooks:
-       - id: ruff
+       - id: ruff-check
          args: [--fix, --show-fixes, --output-format, grouped]
        - id: ruff-format
     - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
The new name is ruff-check, so use
that.