### PR TITLE
CI: cancel previous jobs on PR updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
 
 permissions: {}
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
 
   integration-tests:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   # Always build & lint package.
   build-package:
     name: Build & verify package
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -31,6 +32,7 @@ jobs:
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
     name: Publish released package to pypi.org
+    timeout-minutes: 15
     environment: pypi
     if: github.repository_owner == 'opendatacube' && github.event.action == 'published'
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ on:
 
 permissions: {}
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Always build & lint package.
   build-package:


### PR DESCRIPTION
This avoids clogging the CI machines when one of the quick checks fail and you update the PR to fix that.

Also add a commit that shortens the job timeout in case someone hangs the CI machines.