### PR TITLE
readthedocs: use uv for building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,22 +1,22 @@
-# .readthedocs.yml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
+---
 version: 2
-
-# Build documentation in the docs/ directory with Sphinx
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.10"
-
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
-
-python:
-  install:
-    - requirements: docs/requirements.txt
+# uv build from the documentation at:
+# https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-with-uv
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_checkout:
+      - git fetch --prune --unshallow
+    pre_create_environment:
+       - asdf plugin add uv
+       - asdf install uv latest
+       - asdf global uv latest
+    create_environment:
+       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+       - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra test

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-.
-sphinx-autodoc-typehints


### PR DESCRIPTION
This uses uv.lock for the dependencies,
which eliminates the need for an extra
requirements.txt in docs/.