### PR TITLE
Type annotate type aliases

### DIFF
--- a/eodatasets3/images.py
+++ b/eodatasets3/images.py
@@ -7,9 +7,7 @@ from collections import defaultdict
 from collections.abc import Generator, Iterable, Sequence
 from enum import Enum, auto
 from pathlib import Path, PurePath
-from typing import (
-    ClassVar,
-)
+from typing import ClassVar, TypeAlias
 
 import attr
 import numpy
@@ -286,7 +284,7 @@ class _MeasurementLocation:
     layer: str | None = None
 
 
-_Measurements = dict[str, _MeasurementLocation]
+_Measurements: TypeAlias = dict[str, _MeasurementLocation]
 
 
 class MeasurementBundler:
@@ -1226,7 +1224,7 @@ def _write_quicklook(
     return reproj_grid
 
 
-LazyImages = Iterable[tuple[numpy.ndarray, int]]
+LazyImages: TypeAlias = Iterable[tuple[numpy.ndarray, int]]
 
 
 def _iter_images(rgb: Sequence[Path]) -> LazyImages:

--- a/eodatasets3/model.py
+++ b/eodatasets3/model.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import TypeAlias
 from uuid import UUID
 
 import affine
@@ -13,7 +14,7 @@ ODC_DATASET_SCHEMA_URL = "https://schemas.opendatacube.org/dataset"
 
 # Either a local filesystem path or a string URI.
 # (the URI can use any scheme supported by rasterio, such as tar:// or https:// or ...)
-Location = Path | str
+Location: TypeAlias = Path | str
 
 
 @attr.s(auto_attribs=True, slots=True)

--- a/eodatasets3/properties.py
+++ b/eodatasets3/properties.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from enum import Enum, EnumMeta
 from textwrap import dedent
-from typing import Any
+from typing import Any, TypeAlias
 from urllib.parse import urlencode
 
 import ciso8601
@@ -206,13 +206,13 @@ def parsed_sentinel_datastrip_id(tile_id) -> tuple[str, dict]:
 
 
 # The primitive types allowed as stac values.
-PrimitiveType = str | int | float | datetime.datetime
+PrimitiveType: TypeAlias = str | int | float | datetime.datetime
 
-ExtraProperties = dict
+ExtraProperties: TypeAlias = dict
 # A function to normalise a value.
 # (eg. convert to int, or make string lowercase).
 # They throw a ValueError if not valid.
-NormaliseValueFn = Callable[
+NormaliseValueFn: TypeAlias = Callable[
     [Any],
     # It returns the normalised value, but can optionally also return extra property values extracted from it.
     PrimitiveType | tuple[PrimitiveType, ExtraProperties],

--- a/eodatasets3/scripts/recompress.py
+++ b/eodatasets3/scripts/recompress.py
@@ -21,7 +21,7 @@ from contextlib import suppress
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, TypeAlias
 
 import click
 import numpy
@@ -51,7 +51,7 @@ _PREDICTOR_TABLE = {
 }
 
 # The info of a file, and a method to open the file for reading.
-ReadableMember = tuple[tarfile.TarInfo, Callable[[], IO]]
+ReadableMember: TypeAlias = tuple[tarfile.TarInfo, Callable[[], IO]]
 
 _LOG = structlog.get_logger()
 

--- a/eodatasets3/validate.py
+++ b/eodatasets3/validate.py
@@ -14,9 +14,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from textwrap import indent
-from typing import (
-    Optional,
-)
+from typing import Optional, TypeAlias
 from urllib.parse import urljoin, urlparse
 from urllib.request import urlopen
 
@@ -161,7 +159,7 @@ def _error(code: str, reason: str, hint: str | None = None):
     return ValidationMessage(Level.error, code, reason, hint=hint)
 
 
-ValidationMessages = Generator[ValidationMessage, None, None]
+ValidationMessages: TypeAlias = Generator[ValidationMessage, None, None]
 
 
 @frozen(init=True)
@@ -633,7 +631,7 @@ class ExpectedMeasurement:
 
 
 # Name of a field and its possible offsets in the document.
-FieldNameOffsetS = tuple[str, set[list[str]]]
+FieldNameOffsetS: TypeAlias = tuple[str, set[list[str]]]
 
 
 def validate_paths(

--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -17,7 +17,7 @@ from enum import Enum
 from math import isnan
 from os.path import join
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 from uuid import UUID
 
 import attr
@@ -90,7 +90,7 @@ class ProductMaturity(Enum):
 
 # a dictionary of band_id: (mask_type, mask_uri)
 #     (the mask URI is a string loadable by fiona. Could be a URL or file path.)
-BandMasks = dict[str, tuple[str, str]]
+BandMasks: TypeAlias = dict[str, tuple[str, str]]
 
 
 def _find_h5_paths(h5_obj: h5py.Group, dataset_class: str = "") -> list[str]:

--- a/tests/integration/test_validate.py
+++ b/tests/integration/test_validate.py
@@ -2,6 +2,7 @@ import operator
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from textwrap import dedent
+from typing import TypeAlias
 
 import numpy as np
 import pytest
@@ -15,7 +16,7 @@ from eodatasets3.model import DatasetDoc
 # Either a dict or a path to a document
 from eodatasets3.validate import DocKind, filename_doc_kind, guess_kind_from_contents
 
-Doc = dict | Path
+Doc: TypeAlias = dict | Path
 
 
 @pytest.fixture()


### PR DESCRIPTION
This removes yellow lines on type
annotations in PyCharm.