### PR TITLE
Add `dea_versioned` naming conventions

### DIFF
--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -930,6 +930,14 @@ class DEAS2DerivativesNamingConventions(DEADerivativesNamingConventions):
         )
 
 
+class DEAVersionedNamingConventions(DEANamingConventions):
+    """
+    TODO
+    """
+
+    ...
+
+
 class AfricaProductName:
     def __get__(self, c: "NamingConventions", owner) -> str:
         if c.metadata.product_name:
@@ -976,6 +984,7 @@ class DEAfricaNamingConventions(NamingConventions):
 KNOWN_CONVENTIONS = dict(
     default=NamingConventions,
     dea=DEANamingConventions,
+    dea_versioned=DEAVersionedNamingConventions,
     dea_s2=DEAS2NamingConventions,
     dea_s2_derivative=DEAS2DerivativesNamingConventions,
     dea_c3=DEADerivativesNamingConventions,

--- a/eodatasets3/names.py
+++ b/eodatasets3/names.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from urllib.parse import quote, unquote, urlparse
 
 import datacube.utils.uris as dc_uris
+from packaging.version import Version
 
 from eodatasets3 import utils
 from eodatasets3.model import DEA_URI_PREFIX, Location
@@ -17,11 +18,15 @@ dc_uris.register_scheme("zip", "tar")
 
 class LazyProductName:
     def __init__(
-        self, include_instrument: bool = True, include_collection: bool = False
+        self,
+        include_instrument: bool = True,
+        include_collection: bool = False,
+        include_version: bool = False,
     ) -> None:
         super().__init__()
         self.include_instrument = include_instrument
         self.include_collection = include_collection
+        self.include_version = include_version
 
     def __get__(self, c: "NamingConventions", owner) -> str:
         if c.metadata.product_name:
@@ -47,6 +52,7 @@ class LazyProductName:
                     )
                     else None
                 ),
+                (f"v{c.dataset_version.major}" if self.include_version else None),
             )
             if p
         )
@@ -690,6 +696,10 @@ class NamingConventions:
             return None
         return int(self.metadata.dataset_version.split(".")[0])
 
+    @property
+    def dataset_version(self) -> Version:
+        return Version(self.metadata.dataset_version)
+
     def metadata_filename(self, kind: str = "", suffix: str = "yaml") -> str:
         return self.filename(kind, suffix)
 
@@ -932,10 +942,22 @@ class DEAS2DerivativesNamingConventions(DEADerivativesNamingConventions):
 
 class DEAVersionedNamingConventions(DEANamingConventions):
     """
-    TODO
+    DEA with a version in the product, eg "ga_ls8_cme_3_v1"
+
+    (Sentinel2 needs an extra folder to distinguidh gradules: use s2 versioned for sentinel 2)
     """
 
-    ...
+    product_name: str = LazyProductName(include_collection=True, include_version=True)
+
+
+class DEAS2VersionedNamingConventions(DEAS2NamingConventions):
+    """
+    DEA with a version in the product name, eg "ga_s2_cme_3_v1"
+
+    This is for Sentinel 2, which has an extra subfolder to distinguish granules within a day+region
+    """
+
+    product_name: str = LazyProductName(include_collection=True, include_version=True)
 
 
 class AfricaProductName:
@@ -986,6 +1008,7 @@ KNOWN_CONVENTIONS = dict(
     dea=DEANamingConventions,
     dea_versioned=DEAVersionedNamingConventions,
     dea_s2=DEAS2NamingConventions,
+    dea_s2_versioned=DEAS2VersionedNamingConventions,
     dea_s2_derivative=DEAS2DerivativesNamingConventions,
     dea_c3=DEADerivativesNamingConventions,
     deafrica=DEAfricaNamingConventions,

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -130,7 +130,7 @@ def test_minimal_s2_dataset_normal(tmp_path: Path) -> None:
 def test_dea_new_derivative_s2(tmp_path: Path) -> None:
     assert_names_match(
         tmp_path,
-        conventions="dea_versioned",
+        conventions="dea_s2_versioned",
         properties={
             "eo:platform": "sentinel-2a",
             "eo:instrument": "MSI",
@@ -145,9 +145,9 @@ def test_dea_new_derivative_s2(tmp_path: Path) -> None:
             "odc:region_code": "54JHQ",
             "sentinel:sentinel_tile_id": "S2B_OPER_MSI_L1C_TL_EPAE_20201011T011446_A018789_T55HFA_N02.09",
         },
-        expect_label="ga_s2_cme_3_v1-1-0_54JHQ_2020-10-11_final",
-        expect_metadata_path="ga_s2_cme_3_v1/54/JHQ/2020/10/11/20201011T11446/"
-        "ga_s2_cme_3_v1-1-0_54JHQ_2020-10-11_final.odc-metadata.yaml",
+        expect_label="ga_s2am_cme_3_v1-2-3_54JHQ_2020-10-11_final",
+        expect_metadata_path="ga_s2am_cme_3_v1/54/JHQ/2020/10/11/20201011T011446/"
+        "ga_s2am_cme_3_v1-2-3_54JHQ_2020-10-11_final.odc-metadata.yaml",
     )
 
 

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -127,6 +127,53 @@ def test_minimal_s2_dataset_normal(tmp_path: Path) -> None:
     assert doc["label"] == "s2am_blueberries_2018-11-04", "Unexpected dataset label"
 
 
+def test_dea_new_derivative_s2(tmp_path: Path) -> None:
+    assert_names_match(
+        tmp_path,
+        conventions="dea_versioned",
+        properties={
+            "eo:platform": "sentinel-2a",
+            "eo:instrument": "MSI",
+            "datetime": datetime(2020, 10, 11, 12, 23, 3),
+            "odc:product_family": "cme",
+            "odc:processing_datetime": "2025-10-29T12:23:23",
+            "odc:collection_number": 3,
+            "dea:dataset_maturity": "final",
+            "odc:dataset_version": "1.2.3",
+            "sentinel:datatake_start_datetime": "2025-10-21T05:22:20",
+            "odc:producer": "ga.gov.au",
+            "odc:region_code": "54JHQ",
+            "sentinel:sentinel_tile_id": "S2B_OPER_MSI_L1C_TL_EPAE_20201011T011446_A018789_T55HFA_N02.09",
+        },
+        expect_label="ga_s2_cme_3_v1-1-0_54JHQ_2020-10-11_final",
+        expect_metadata_path="ga_s2_cme_3_v1/54/JHQ/2020/10/11/20201011T11446/"
+        "ga_s2_cme_3_v1-1-0_54JHQ_2020-10-11_final.odc-metadata.yaml",
+    )
+
+
+def test_dea_new_derivative_ls(tmp_path: Path) -> None:
+    assert_names_match(
+        tmp_path,
+        conventions="dea_versioned",
+        properties={
+            "eo:platform": "landsat-8",
+            "eo:instrument": "OLI_TIRS",
+            "datetime": datetime(2025, 9, 16, 5, 23, 3),
+            "odc:product_family": "cme",
+            "odc:processing_datetime": "2025-09-20T12:23:23",
+            "odc:collection_number": 3,
+            "dea:dataset_maturity": "final",
+            "odc:dataset_version": "1.2.3",
+            "landsat:landsat_product_id": "LC08_L1TP_093076_20250916_20250920_02_T1",
+            "odc:producer": "ga.gov.au",
+            "odc:region_code": "093076",
+        },
+        expect_label="ga_ls8c_cme_3_v1-2-3_093076_2025-10-22_final",
+        expect_metadata_path="ga_ls8c_cme_3_v1/092/084/2025/10/22/"
+        "ga_ls8c_cme_3_v1-1-0_093076_2025-10-22_final.odc-metadata.yaml",
+    )
+
+
 def test_s2_naming_conventions(tmp_path: Path) -> None:
     """A minimal dataset with sentinel platform/instrument"""
     p = DatasetAssembler(tmp_path, naming_conventions="dea_s2")

--- a/tests/integration/test_naming_conventions.py
+++ b/tests/integration/test_naming_conventions.py
@@ -127,7 +127,7 @@ def test_minimal_s2_dataset_normal(tmp_path: Path) -> None:
     assert doc["label"] == "s2am_blueberries_2018-11-04", "Unexpected dataset label"
 
 
-def test_dea_new_derivative_s2(tmp_path: Path) -> None:
+def test_dea_versioned_s2(tmp_path: Path) -> None:
     assert_names_match(
         tmp_path,
         conventions="dea_s2_versioned",
@@ -151,7 +151,7 @@ def test_dea_new_derivative_s2(tmp_path: Path) -> None:
     )
 
 
-def test_dea_new_derivative_ls(tmp_path: Path) -> None:
+def test_dea_versioned_ls(tmp_path: Path) -> None:
     assert_names_match(
         tmp_path,
         conventions="dea_versioned",
@@ -168,9 +168,9 @@ def test_dea_new_derivative_ls(tmp_path: Path) -> None:
             "odc:producer": "ga.gov.au",
             "odc:region_code": "093076",
         },
-        expect_label="ga_ls8c_cme_3_v1-2-3_093076_2025-10-22_final",
-        expect_metadata_path="ga_ls8c_cme_3_v1/092/084/2025/10/22/"
-        "ga_ls8c_cme_3_v1-1-0_093076_2025-10-22_final.odc-metadata.yaml",
+        expect_label="ga_ls8c_cme_3_v1-2-3_093076_2025-09-16_final",
+        expect_metadata_path="ga_ls8c_cme_3_v1/093/076/2025/09/16/"
+        "ga_ls8c_cme_3_v1-2-3_093076_2025-09-16_final.odc-metadata.yaml",
     )
 
 


### PR DESCRIPTION
Adds options `conventions="dea_versioned"` and `conventions="dea_s2_versioned"`.

It would be nice to combine them into one naming convention, but that would require a bigger refactor of eodatasets: they could no longer be static, as the conventions would have to change slightly depending on satellite.