### PR TITLE
Dockerfile: pin to GDAL 3.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # This gdal version should match the "gdal=="
 # line in setup.py's "docker"
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.11.1
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.3@sha256:dab45abca3ca83695d442018692f4f8a0f41955871c57e6101d7f89a92375caa AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \


### PR DESCRIPTION
Downgrade to GDAL 3.10.3 that
all the other repositories currently
use, and pin the image by hash.