### PR TITLE
Dependabot: remove boto3+botocore update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,24 +22,11 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       uv-deps:
         patterns:
           - "*"
         exclude-patterns: # Packages updated almost every day.
-          - "boto3"
-          - "botocore"
-  - package-ecosystem: "uv"
-    # Have two jobs with same eco-system/directory by setting target-branch
-    # for one of them:
-    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
-    target-branch: "develop"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      uv-weekly-deps:
-        patterns:
           - "boto3"
           - "botocore"


### PR DESCRIPTION
Dependabot makes pull requests for boto3
and botocore every day, so this workaround
might no longer be applicable. Remove
it for now and hope we get automatic
updates for the rest of our dependencies.