### PR TITLE
wagl metadata: Fall back to nbart time range calculation when nbar not available

### DIFF
--- a/eodatasets3/wagl.py
+++ b/eodatasets3/wagl.py
@@ -459,7 +459,7 @@ def _create_contiguity(
     p: DatasetAssembler,
     product_list: Iterable[str],
     resolution_yx: tuple[float, float],
-    timedelta_product: str = "nbar",
+    timedelta_products: Iterable[str] = ("nbar", "nbart"),
     timedelta_data: numpy.ndarray | None = None,
 ):
     """
@@ -468,6 +468,13 @@ def _create_contiguity(
     Write a contiguity mask file based on the intersection of valid data pixels across all
     bands from the input files.
     """
+
+    # Calculate the time range from the first that we have available
+    timedelta_product = next(
+        (preferred for preferred in timedelta_products if preferred in product_list),
+        None,
+    )
+
     for product in product_list:
         contiguity = None
         # A contiguity layer for each product


### PR DESCRIPTION
Now that nbar is being disabled for Landsat scenes, this change is required so that we still include the time range in the metadata.

(the modified function is private in the file, so this does not change the public api)